### PR TITLE
Add tool product pages

### DIFF
--- a/products.html
+++ b/products.html
@@ -276,13 +276,8 @@
                         </div>
                     </details>
 
-                    <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <a href="products/overwatch/phantom.html" class="block" rel="noopener">
                         <button class="w-full py-3 rounded-lg bg-gradient-to-r from-green-500 to-matrix hover:opacity-90 transition font-bold">
-                            Buy Now
-                        </button>
-                    </a>
-                    <a href="products/overwatch/phantom.html" class="block mt-3" rel="noopener">
-                        <button class="w-full py-3 rounded-lg border border-matrix text-matrix hover:bg-matrix/10 transition font-bold">
                             View Product
                         </button>
                     </a>
@@ -367,13 +362,8 @@
                         </div>
                     </details>
 
-                    <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <a href="products/overwatch/dominion.html" class="block" rel="noopener">
                         <button class="w-full py-3 rounded-lg bg-gradient-to-r from-green-500 to-matrix hover:opacity-90 transition font-bold">
-                            Buy Now
-                        </button>
-                    </a>
-                    <a href="products/overwatch/dominion.html" class="block mt-3" rel="noopener">
-                        <button class="w-full py-3 rounded-lg border border-matrix text-matrix hover:bg-matrix/10 transition font-bold">
                             View Product
                         </button>
                     </a>
@@ -459,13 +449,8 @@
                         </div>
                     </details>
 
-                    <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <a href="products/overwatch/godmode.html" class="block" rel="noopener">
                         <button class="w-full py-3 rounded-lg bg-gradient-to-r from-green-500 to-matrix hover:opacity-90 transition font-bold">
-                            Buy Now
-                        </button>
-                    </a>
-                    <a href="products/overwatch/godmode.html" class="block mt-3" rel="noopener">
-                        <button class="w-full py-3 rounded-lg border border-matrix text-matrix hover:bg-matrix/10 transition font-bold">
                             View Product
                         </button>
                     </a>
@@ -538,9 +523,9 @@
                         </div>
                     </details>
 
-                    <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <a href="products/cr/supreme.html" class="block" rel="noopener">
                         <button class="w-full py-3 rounded-lg bg-gradient-to-r from-primary to-accent hover:opacity-90 transition font-bold">
-                            Buy Now
+                            View Product
                         </button>
                     </a>
 
@@ -611,9 +596,9 @@
                         </div>
                     </details>
                     
-                    <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <a href="products/cr/dominator.html" class="block" rel="noopener">
                         <button class="w-full py-3 rounded-lg bg-gradient-to-r from-primary to-accent hover:opacity-90 transition font-bold">
-                            Buy Now
+                            View Product
                         </button>
                     </a>
 
@@ -689,9 +674,9 @@
                         </div>
                     </details>
                     
-                    <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <a href="products/cr/godmode.html" class="block" rel="noopener">
                         <button class="w-full py-3 rounded-lg bg-gradient-to-r from-primary to-accent hover:opacity-90 transition font-bold">
-                            Buy Now
+                            View Product
                         </button>
                     </a>
                 </div>
@@ -770,17 +755,13 @@
                         </div>
                     </details>
 
-                    <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <a href="products/warzone/reaper.html" class="block" rel="noopener">
                         <button class="w-full py-3 rounded-lg bg-gradient-to-r from-primary to-accent hover:opacity-90 transition font-bold">
-                            Buy Now
-                        </button>
-                    </a>
-                </div>
-                    <a href="products/warzone/reaper.html" class="block mt-3" rel="noopener">
-                        <button class="w-full py-3 rounded-lg border border-accent text-accent hover:bg-accent/10 transition font-bold">
                             View Product
                         </button>
                     </a>
+
+                </div>
 
 
                 <!-- Warzone Reaper 2 -->
@@ -843,13 +824,8 @@
                         </div>
                     </details>
 
-                    <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <a href="products/warzone/reaper2.html" class="block" rel="noopener">
                         <button class="w-full py-3 rounded-lg bg-gradient-to-r from-primary to-accent hover:opacity-90 transition font-bold">
-                            Buy Now
-                        </button>
-                    </a>
-                    <a href="products/warzone/reaper2.html" class="block mt-3" rel="noopener">
-                        <button class="w-full py-3 rounded-lg border border-accent text-accent hover:bg-accent/10 transition font-bold">
                             View Product
                         </button>
                     </a>
@@ -914,17 +890,11 @@
                         </div>
                     </details>
                     
-                    <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <a href="products/tools/universal-injector.html">
                         <button class="w-full py-3 rounded-lg bg-gradient-to-r from-primary to-accent hover:opacity-90 transition font-bold">
-                            Buy Now
+                            View Product
                         </button>
                     </a>
-                </div>
-
-                <!-- Performance Optimizer -->
-                <div class="card-gradient p-6 rounded-xl transition duration-500">
-                    <div class="flex justify-between items-start mb-6">
-                        <div>
                             <div class="w-14 h-14 rounded-lg bg-accent/20 flex items-center justify-center mb-4">
                                 <i class="fas fa-tachometer-alt text-2xl text-accent"></i>
                             </div>
@@ -973,9 +943,9 @@
                         </div>
                     </details>
                     
-                    <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <a href="products/tools/performance-optimizer.html">
                         <button class="w-full py-3 rounded-lg bg-gradient-to-r from-primary to-accent hover:opacity-90 transition font-bold">
-                            Buy Now
+                            View Product
                         </button>
                     </a>
                 </div>
@@ -1032,9 +1002,9 @@
                         </div>
                     </details>
                     
-                    <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <a href="products/tools/streamer-shield.html">
                         <button class="w-full py-3 rounded-lg bg-gradient-to-r from-primary to-accent hover:opacity-90 transition font-bold">
-                            Buy Now
+                            View Product
                         </button>
                     </a>
                 </div>

--- a/products/cr/dominator.html
+++ b/products/cr/dominator.html
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <!-- products/warzone/reaper.html -->
+    <!-- products/cr/dominator.html -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>COD Warzone Reaper | Hackboot - Premium Stealth Cheat</title>
+    <title>Clash Royale Dominator | Hackboot - Arena Domination</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="shortcut icon" href="../../img/favicon.ico" />
 
-    <meta name="description" content="COD Warzone Reaper - Advanced aimbot, full ESP and secure VM. €600/month. Zero detection and complete control.">
+    <meta name="description" content="Clash Royale Dominator - Advanced features, AI assistance and rooted VM. €230/month. Total control.">
     <meta name="robots" content="index, follow">
     
     <!-- Open Graph -->
-    <meta property="og:title" content="COD Warzone Reaper | Hackboot">
-    <meta property="og:description" content="Premium Warzone cheat with advanced aimbot, full ESP and secure VM. Zero detection guaranteed.">
+    <meta property="og:title" content="Clash Royale Dominator | Hackboot">
+    <meta property="og:description" content="Advanced Clash Royale pack with AI recommendations and dedicated VM.">
     <meta property="og:type" content="product">
     
     <!-- Canonical -->
-    <link rel="canonical" href="https://hackboot.fr/products/warzone/reaper.html" />
+    <link rel="canonical" href="https://hackboot.fr/products/cr/dominator.html" />
 
     <script>
         tailwind.config = {
@@ -187,7 +187,7 @@
             <i class="fas fa-chevron-right text-xs"></i>
             <a href="../../index.html#products" class="hover:text-accent transition">Products</a>
             <i class="fas fa-chevron-right text-xs"></i>
-            <span class="text-matrix">COD Warzone Reaper</span>
+            <span class="text-matrix">Clash Royale Dominator</span>
         </div>
     </div>
 
@@ -202,28 +202,27 @@
                             <i class="fas fa-crown text-xl text-white"></i>
                         </div>
                         <div>
-                            <span class="text-sm text-gray-400 uppercase tracking-wider">COD Warzone</span>
+                            <span class="text-sm text-gray-400 uppercase tracking-wider">Clash Royale</span>
                             <h1 class="text-3xl lg:text-4xl font-bold matrix-gradient matrix-glow">
-                                Reaper
+                                Dominator
                             </h1>
                         </div>
                     </div>
                     
-                    <p class="text-xl text-gray-300 mb-2">
-                        <span class="gradient-text font-semibold">Total Domination &amp; Zero Detection</span>
+                        <span class="gradient-text font-semibold">Advanced Pack Arena Domination &amp; No Limitsamp; Total Control</span>
                     </p>
                     <p class="text-gray-400 mb-6 text-lg leading-relaxed">
-                        Reaper Pack offers unmatched control for COD Warzone. Advanced aimbot, extensive ESP and a secure VM with hardware spoofing for dominating every match.
+                        Dominator Pack delivers AI recommendations, smart placement and a rooted VM for total arena control.
                     </p>
                     
                     <!-- Price -->
                     <div class="mb-8">
                         <div class="flex items-baseline space-x-2 mb-2">
-                            <span class="text-4xl font-bold text-matrix">€600</span>
+                            <span class="text-4xl font-bold text-matrix">€230</span>
                             <span class="text-gray-400 text-lg">/month</span>
                         </div>
                         <div class="flex items-center space-x-2">
-                            <span class="text-sm bg-matrix/20 text-matrix px-3 py-1 rounded-full">PACK 1</span>
+                            <span class="text-sm bg-matrix/20 text-matrix px-3 py-1 rounded-full">PACK 2</span>
                             <span class="text-sm bg-accent/20 text-accent px-3 py-1 rounded-full">STANDARD</span>
                         </div>
                     </div>
@@ -309,7 +308,7 @@
                     <span class="gradient-text">Ultimate</span> <span class="text-white">Features</span>
                 </h2>
                 <p class="text-gray-400 max-w-2xl mx-auto">
-                    The complete suite of advanced features for an unlimited COD Warzone experience.
+                    The complete suite of advanced features for an unlimited Clash Royale experience.
                 </p>
             </div>
             
@@ -325,31 +324,51 @@
                     <ul class="space-y-2 text-sm text-gray-300">
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Advanced aimbot with bone selection
+                            Full card tracking (hand, cycle, next card)
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Full ESP: players, loot & objectives
+                            Opponent elixir estimation (OCR / memory)
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Smart triggerbot & radar hack
+                            AI recommendation (automated optimal play)
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            No recoil & bullet teleport
+                            Smart placement (defense, split, kiting)
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            AI prediction & FOV unlock
+                            Strategic overlay (range, impact, paths)
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Anti-flash & anti-smoke
+                            Auto-match & AFK farming
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Auto ping & killstreak automation
+                            Auto-claim rewards & quests
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Auto deck switch (live meta)
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Deck sniping (live adaptation for multi-account)
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Matchmaking spoofing (anti-target)
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Network desync / soft DDoS
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Modified packet injection (experimental)
                         </li>
                     </ul>
                 </div>
@@ -365,15 +384,31 @@
                     <ul class="space-y-2 text-sm text-gray-300">
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Stat faker (K/D, accuracy, wins)
+                            All cards unlocked at level 15
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Maxed weapon levels & full unlock
+                            All evolutions activated
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            SBMM bypass / manual matchmaking
+                            Full cosmetics (skins, emotes, banners)
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Immediate Royale Pass unlock
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Full access to ladder decks and events
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Free nickname and tag change
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Fake level / fake progression (XP, badges)
                         </li>
                     </ul>
                 </div>
@@ -439,33 +474,31 @@
                     </h3>
                     <div class="space-y-4">
                         <div class="spec-highlight p-4 rounded-lg">
-                            <h4 class="font-semibold text-matrix mb-2">Advanced Aimbot</h4>
+                            <h4 class="font-semibold text-matrix mb-2">Full Card Tools</h4>
                             <ul class="text-sm text-gray-300 space-y-1">
-                                <li>• Adjustable FOV (10-180°)</li>
-                                <li>• Customizable smoothing (0-100%)</li>
-                                <li>• Silent aim invisible to spectators</li>
-                                <li>• Bone selection (head, chest, feet)</li>
-                                <li>• Dynamic movement prediction</li>
+                                <li>• Full card tracking (hand, cycle, next card)</li>
+                                <li>• Real-time opponent elixir estimation</li>
+                                <li>• Strategic overlay (range, impact, paths)</li>
+                                <li>• Auto-match & 24/7 farming</li>
+                                <li>• Automatic deck switch (meta based)</li>
+                            <h4 class="font-semibold text-matrix mb-2">Unlocked Content</h4>
+                            <ul class="text-sm text-gray-300 space-y-1">
+                                <li>• All cards at level 15</li>
+                                <li>• All evolutions unlocked</li>
+                                <li>• Access to ladder decks & events</li>
+                                <li>• All cosmetics unlocked</li>
+                                <li>• Free nickname & tag change</li>
                             </ul>
                         </div>
                         
                         <div class="spec-highlight p-4 rounded-lg">
-                            <h4 class="font-semibold text-matrix mb-2">Total Unlocks</h4>
+                            <h4 class="font-semibold text-matrix mb-2">Automation Tools</h4>
                             <ul class="text-sm text-gray-300 space-y-1">
-                                  <li>• Stat faker (K/D, accuracy, wins)</li>
-                                  <li>• Max weapon levels & full unlock</li>
-                                  <li>• SBMM bypass / manual matchmaking</li>
-                            </ul>
-                        </div>
-                        
-                        <div class="spec-highlight p-4 rounded-lg">
-                            <h4 class="font-semibold text-matrix mb-2">AI & Automation</h4>
-                            <ul class="text-sm text-gray-300 space-y-1">
-                                <li>• AI-driven automated gameplay</li>
-                                <li>• Auto skill activation</li>
-                                <li>• Built-in macro/script editor</li>
-                                <li>• Smart anti-spectator mode</li>
-                                <li>• Behavioral humanization</li>
+                                <li>• Auto-claim chests & quests</li>
+                                <li>• Smart placement suggestions</li>
+                                <li>• AI deck prediction</li>
+                                <li>• Opponent cycle tracking</li>
+                                <li>• Matchmaking spoofing (target bypass)</li>
                             </ul>
                         </div>
                     </div>
@@ -504,7 +537,7 @@
                             <ul class="text-sm text-gray-300 space-y-1">
                                 <li>• OBS & ShadowPlay compatible</li>
                                 <li>• Automatic VM snapshots</li>
-                                <li>• Fail-safe on Warzone updates</li>
+                                <li>• Fail-safe on game updates</li>
                                 <li>• Secure authentication (2FA)</li>
                                 <li>• One-click full reset</li>
                             </ul>
@@ -564,7 +597,7 @@
                     </button>
                     <div id="faq-content-1" class="hidden mt-4 text-gray-300">
                         <p>
-                            The skin unlocker only works visually while you use Reaper. Skins appear unlocked on your screen, but they are not permanently added to your Blizzard account.
+                            The skin unlocker only works visually while you use Dominator. Skins appear unlocked on your screen, but they are not permanently added to your Blizzard account.
                         </p>
                     </div>
                 </div>
@@ -577,7 +610,7 @@
                     </button>
                     <div id="faq-content-2" class="hidden mt-4 text-gray-300">
                         <p>
-                            Reaper locally modifies the display of your level, portrait, stats and rank. You appear with the desired level (up to 999) and custom stats, but it's purely cosmetic.
+                            Dominator locally modifies the display of your level, portrait, stats and rank. You appear with the desired level (up to 999) and custom stats, but it's purely cosmetic.
                         </p>
                     </div>
                 </div>
@@ -585,12 +618,12 @@
                 <!-- Question 3 -->
                 <div class="card-gradient p-6 rounded-xl">
                     <button onclick="toggleFAQ(3)" class="flex justify-between items-center w-full">
-                        <h3 class="text-lg font-bold text-left">Can I stream with Reaper?</h3>
+                        <h3 class="text-lg font-bold text-left">Can I stream with Dominator?</h3>
                         <i id="faq-icon-3" class="fas fa-chevron-down transition-transform duration-300"></i>
                     </button>
                     <div id="faq-content-3" class="hidden mt-4 text-gray-300">
                         <p>
-                            Yes! Reaper is optimized for streaming with OBS and ShadowPlay. The anti-spectator mode automatically hides all cheat features when you're watched.
+                            Yes! Dominator is optimized for streaming with OBS and ShadowPlay. The anti-spectator mode automatically hides all cheat features when you're watched.
                         </p>
                     </div>
                 </div>
@@ -598,12 +631,12 @@
                 <!-- Question 4 -->
                 <div class="card-gradient p-6 rounded-xl">
                     <button onclick="toggleFAQ(4)" class="flex justify-between items-center w-full">
-                        <h3 class="text-lg font-bold text-left">What happens if Warzone updates?</h3>
+                        <h3 class="text-lg font-bold text-left">What happens if Clash Royale updates?</h3>
                         <i id="faq-icon-4" class="fas fa-chevron-down transition-transform duration-300"></i>
                     </button>
                     <div id="faq-content-4" class="hidden mt-4 text-gray-300">
                         <p>
-                            Reaper includes a fail-safe system that automatically disables the cheat when COD Warzone updates. Our team updates the software within 24-48h to stay compatible.
+                            Dominator includes a fail-safe system that automatically disables the cheat when Clash Royale updates. Our team updates the software within 24-48h to stay compatible.
                         </p>
                     </div>
                 </div>
@@ -619,7 +652,7 @@
                     <span class="matrix-gradient">Access</span> <span class="text-white">Absolute Control</span>
                 </h2>
                 <p class="text-gray-300 mb-8 max-w-2xl mx-auto">
-                    Join the fight with Reaper and enjoy unbeatable precision at an affordable price.
+                    Join the fight with Dominator and enjoy unbeatable precision at an affordable price.
                 </p>
                 
                 <!-- Package details -->
@@ -645,7 +678,7 @@
                     <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
                         <button class="px-10 py-4 rounded-lg bg-gradient-to-r from-matrix to-primary hover:scale-105 transition transform duration-300 font-bold shadow-lg text-lg">
                             <i class="fas fa-rocket mr-2"></i>
-                            Order Reaper - €600/month
+                            Order Dominator - €230/month
                         </button>
                     </a>
                     <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
@@ -701,7 +734,7 @@
                         </div>
                         <div>
                             <h3 class="text-lg font-bold">Warzone Reaper</h3>
-                            <p class="text-sm text-gray-400">€600/month</p>
+                            <p class="text-sm text-gray-400">€230/month</p>
                         </div>
                     </div>
                     <p class="text-gray-300 text-sm mb-4">

--- a/products/cr/godmode.html
+++ b/products/cr/godmode.html
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <!-- products/warzone/reaper.html -->
+    <!-- products/cr/godmode.html -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>COD Warzone Reaper | Hackboot - Premium Stealth Cheat</title>
+    <title>Clash Royale Godmode | Hackboot - Arena Domination</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="shortcut icon" href="../../img/favicon.ico" />
 
-    <meta name="description" content="COD Warzone Reaper - Advanced aimbot, full ESP and secure VM. €600/month. Zero detection and complete control.">
+    <meta name="description" content="Clash Royale Godmode - Powerful infrastructure with 8GB rooted VM and full anonymity. €290/month.">
     <meta name="robots" content="index, follow">
     
     <!-- Open Graph -->
-    <meta property="og:title" content="COD Warzone Reaper | Hackboot">
-    <meta property="og:description" content="Premium Warzone cheat with advanced aimbot, full ESP and secure VM. Zero detection guaranteed.">
+    <meta property="og:title" content="Clash Royale Godmode | Hackboot">
+    <meta property="og:description" content="Ultimate Clash Royale package with high-performance VM and stealth features.">
     <meta property="og:type" content="product">
     
     <!-- Canonical -->
-    <link rel="canonical" href="https://hackboot.fr/products/warzone/reaper.html" />
+    <link rel="canonical" href="https://hackboot.fr/products/cr/godmode.html" />
 
     <script>
         tailwind.config = {
@@ -187,7 +187,7 @@
             <i class="fas fa-chevron-right text-xs"></i>
             <a href="../../index.html#products" class="hover:text-accent transition">Products</a>
             <i class="fas fa-chevron-right text-xs"></i>
-            <span class="text-matrix">COD Warzone Reaper</span>
+            <span class="text-matrix">Clash Royale Godmode</span>
         </div>
     </div>
 
@@ -202,28 +202,26 @@
                             <i class="fas fa-crown text-xl text-white"></i>
                         </div>
                         <div>
-                            <span class="text-sm text-gray-400 uppercase tracking-wider">COD Warzone</span>
+                            <span class="text-sm text-gray-400 uppercase tracking-wider">Clash Royale</span>
                             <h1 class="text-3xl lg:text-4xl font-bold matrix-gradient matrix-glow">
-                                Reaper
+                                Godmode
                             </h1>
                         </div>
                     </div>
                     
-                    <p class="text-xl text-gray-300 mb-2">
-                        <span class="gradient-text font-semibold">Total Domination &amp; Zero Detection</span>
-                    </p>
+                        <span class="gradient-text font-semibold">Maximum Power &amp; Total Security</span>
                     <p class="text-gray-400 mb-6 text-lg leading-relaxed">
-                        Reaper Pack offers unmatched control for COD Warzone. Advanced aimbot, extensive ESP and a secure VM with hardware spoofing for dominating every match.
+                        Godmode Pack unlocks maximum performance and full anonymity with an 8GB rooted VM.
                     </p>
                     
                     <!-- Price -->
                     <div class="mb-8">
                         <div class="flex items-baseline space-x-2 mb-2">
-                            <span class="text-4xl font-bold text-matrix">€600</span>
+                            <span class="text-4xl font-bold text-matrix">€290</span>
                             <span class="text-gray-400 text-lg">/month</span>
                         </div>
                         <div class="flex items-center space-x-2">
-                            <span class="text-sm bg-matrix/20 text-matrix px-3 py-1 rounded-full">PACK 1</span>
+                            <span class="text-sm bg-matrix/20 text-matrix px-3 py-1 rounded-full">PACK 3</span>
                             <span class="text-sm bg-accent/20 text-accent px-3 py-1 rounded-full">STANDARD</span>
                         </div>
                     </div>
@@ -309,7 +307,7 @@
                     <span class="gradient-text">Ultimate</span> <span class="text-white">Features</span>
                 </h2>
                 <p class="text-gray-400 max-w-2xl mx-auto">
-                    The complete suite of advanced features for an unlimited COD Warzone experience.
+                    The complete suite of advanced features for an unlimited Clash Royale experience.
                 </p>
             </div>
             
@@ -325,31 +323,51 @@
                     <ul class="space-y-2 text-sm text-gray-300">
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Advanced aimbot with bone selection
+                            Full card tracking (hand, cycle, next card)
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Full ESP: players, loot & objectives
+                            Opponent elixir estimation (OCR / memory)
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Smart triggerbot & radar hack
+                            AI recommendation (automated optimal play)
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            No recoil & bullet teleport
+                            Smart placement (defense, split, kiting)
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            AI prediction & FOV unlock
+                            Strategic overlay (range, impact, paths)
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Anti-flash & anti-smoke
+                            Auto-match & AFK farming
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Auto ping & killstreak automation
+                            Auto-claim rewards & quests
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Auto deck switch (live meta)
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Deck sniping (live adaptation for multi-account)
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Matchmaking spoofing (anti-target)
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Network desync / soft DDoS
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Modified packet injection (experimental)
                         </li>
                     </ul>
                 </div>
@@ -365,15 +383,31 @@
                     <ul class="space-y-2 text-sm text-gray-300">
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Stat faker (K/D, accuracy, wins)
+                            All cards unlocked at level 15
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Maxed weapon levels & full unlock
+                            All evolutions activated
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            SBMM bypass / manual matchmaking
+                            Full cosmetics (skins, emotes, banners)
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Immediate Royale Pass unlock
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Full access to ladder decks and events
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Free nickname and tag change
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Fake level / fake progression (XP, badges)
                         </li>
                     </ul>
                 </div>
@@ -439,33 +473,31 @@
                     </h3>
                     <div class="space-y-4">
                         <div class="spec-highlight p-4 rounded-lg">
-                            <h4 class="font-semibold text-matrix mb-2">Advanced Aimbot</h4>
+                            <h4 class="font-semibold text-matrix mb-2">Full Card Tools</h4>
                             <ul class="text-sm text-gray-300 space-y-1">
-                                <li>• Adjustable FOV (10-180°)</li>
-                                <li>• Customizable smoothing (0-100%)</li>
-                                <li>• Silent aim invisible to spectators</li>
-                                <li>• Bone selection (head, chest, feet)</li>
-                                <li>• Dynamic movement prediction</li>
+                                <li>• Full card tracking (hand, cycle, next card)</li>
+                                <li>• Real-time opponent elixir estimation</li>
+                                <li>• Strategic overlay (range, impact, paths)</li>
+                                <li>• Auto-match & 24/7 farming</li>
+                                <li>• Automatic deck switch (meta based)</li>
+                            <h4 class="font-semibold text-matrix mb-2">Unlocked Content</h4>
+                            <ul class="text-sm text-gray-300 space-y-1">
+                                <li>• All cards at level 15</li>
+                                <li>• All evolutions unlocked</li>
+                                <li>• Access to ladder decks & events</li>
+                                <li>• All cosmetics unlocked</li>
+                                <li>• Free nickname & tag change</li>
                             </ul>
                         </div>
                         
                         <div class="spec-highlight p-4 rounded-lg">
-                            <h4 class="font-semibold text-matrix mb-2">Total Unlocks</h4>
+                            <h4 class="font-semibold text-matrix mb-2">Automation Tools</h4>
                             <ul class="text-sm text-gray-300 space-y-1">
-                                  <li>• Stat faker (K/D, accuracy, wins)</li>
-                                  <li>• Max weapon levels & full unlock</li>
-                                  <li>• SBMM bypass / manual matchmaking</li>
-                            </ul>
-                        </div>
-                        
-                        <div class="spec-highlight p-4 rounded-lg">
-                            <h4 class="font-semibold text-matrix mb-2">AI & Automation</h4>
-                            <ul class="text-sm text-gray-300 space-y-1">
-                                <li>• AI-driven automated gameplay</li>
-                                <li>• Auto skill activation</li>
-                                <li>• Built-in macro/script editor</li>
-                                <li>• Smart anti-spectator mode</li>
-                                <li>• Behavioral humanization</li>
+                                <li>• Auto-claim chests & quests</li>
+                                <li>• Smart placement suggestions</li>
+                                <li>• AI deck prediction</li>
+                                <li>• Opponent cycle tracking</li>
+                                <li>• Matchmaking spoofing (target bypass)</li>
                             </ul>
                         </div>
                     </div>
@@ -504,7 +536,7 @@
                             <ul class="text-sm text-gray-300 space-y-1">
                                 <li>• OBS & ShadowPlay compatible</li>
                                 <li>• Automatic VM snapshots</li>
-                                <li>• Fail-safe on Warzone updates</li>
+                                <li>• Fail-safe on game updates</li>
                                 <li>• Secure authentication (2FA)</li>
                                 <li>• One-click full reset</li>
                             </ul>
@@ -564,7 +596,7 @@
                     </button>
                     <div id="faq-content-1" class="hidden mt-4 text-gray-300">
                         <p>
-                            The skin unlocker only works visually while you use Reaper. Skins appear unlocked on your screen, but they are not permanently added to your Blizzard account.
+                            The skin unlocker only works visually while you use Godmode. Skins appear unlocked on your screen, but they are not permanently added to your Blizzard account.
                         </p>
                     </div>
                 </div>
@@ -577,7 +609,7 @@
                     </button>
                     <div id="faq-content-2" class="hidden mt-4 text-gray-300">
                         <p>
-                            Reaper locally modifies the display of your level, portrait, stats and rank. You appear with the desired level (up to 999) and custom stats, but it's purely cosmetic.
+                            Godmode locally modifies the display of your level, portrait, stats and rank. You appear with the desired level (up to 999) and custom stats, but it's purely cosmetic.
                         </p>
                     </div>
                 </div>
@@ -585,12 +617,12 @@
                 <!-- Question 3 -->
                 <div class="card-gradient p-6 rounded-xl">
                     <button onclick="toggleFAQ(3)" class="flex justify-between items-center w-full">
-                        <h3 class="text-lg font-bold text-left">Can I stream with Reaper?</h3>
+                        <h3 class="text-lg font-bold text-left">Can I stream with Godmode?</h3>
                         <i id="faq-icon-3" class="fas fa-chevron-down transition-transform duration-300"></i>
                     </button>
                     <div id="faq-content-3" class="hidden mt-4 text-gray-300">
                         <p>
-                            Yes! Reaper is optimized for streaming with OBS and ShadowPlay. The anti-spectator mode automatically hides all cheat features when you're watched.
+                            Yes! Godmode is optimized for streaming with OBS and ShadowPlay. The anti-spectator mode automatically hides all cheat features when you're watched.
                         </p>
                     </div>
                 </div>
@@ -598,12 +630,12 @@
                 <!-- Question 4 -->
                 <div class="card-gradient p-6 rounded-xl">
                     <button onclick="toggleFAQ(4)" class="flex justify-between items-center w-full">
-                        <h3 class="text-lg font-bold text-left">What happens if Warzone updates?</h3>
+                        <h3 class="text-lg font-bold text-left">What happens if Clash Royale updates?</h3>
                         <i id="faq-icon-4" class="fas fa-chevron-down transition-transform duration-300"></i>
                     </button>
                     <div id="faq-content-4" class="hidden mt-4 text-gray-300">
                         <p>
-                            Reaper includes a fail-safe system that automatically disables the cheat when COD Warzone updates. Our team updates the software within 24-48h to stay compatible.
+                            Godmode includes a fail-safe system that automatically disables the cheat when Clash Royale updates. Our team updates the software within 24-48h to stay compatible.
                         </p>
                     </div>
                 </div>
@@ -619,7 +651,7 @@
                     <span class="matrix-gradient">Access</span> <span class="text-white">Absolute Control</span>
                 </h2>
                 <p class="text-gray-300 mb-8 max-w-2xl mx-auto">
-                    Join the fight with Reaper and enjoy unbeatable precision at an affordable price.
+                    Join the fight with Godmode and enjoy unbeatable precision at an affordable price.
                 </p>
                 
                 <!-- Package details -->
@@ -645,7 +677,7 @@
                     <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
                         <button class="px-10 py-4 rounded-lg bg-gradient-to-r from-matrix to-primary hover:scale-105 transition transform duration-300 font-bold shadow-lg text-lg">
                             <i class="fas fa-rocket mr-2"></i>
-                            Order Reaper - €600/month
+                            Order Godmode - €290/month
                         </button>
                     </a>
                     <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
@@ -701,7 +733,7 @@
                         </div>
                         <div>
                             <h3 class="text-lg font-bold">Warzone Reaper</h3>
-                            <p class="text-sm text-gray-400">€600/month</p>
+                            <p class="text-sm text-gray-400">€290/month</p>
                         </div>
                     </div>
                     <p class="text-gray-300 text-sm mb-4">

--- a/products/cr/supreme.html
+++ b/products/cr/supreme.html
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <!-- products/warzone/reaper.html -->
+    <!-- products/cr/supreme.html -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>COD Warzone Reaper | Hackboot - Premium Stealth Cheat</title>
+    <title>Clash Royale Supreme | Hackboot - Arena Domination</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="shortcut icon" href="../../img/favicon.ico" />
 
-    <meta name="description" content="COD Warzone Reaper - Advanced aimbot, full ESP and secure VM. €600/month. Zero detection and complete control.">
+    <meta name="description" content="Clash Royale Supreme - Full card tracking, elixir estimation and rooted VM. €180/month. Dominate the arena.">
     <meta name="robots" content="index, follow">
     
     <!-- Open Graph -->
-    <meta property="og:title" content="COD Warzone Reaper | Hackboot">
-    <meta property="og:description" content="Premium Warzone cheat with advanced aimbot, full ESP and secure VM. Zero detection guaranteed.">
+    <meta property="og:title" content="Clash Royale Supreme | Hackboot">
+    <meta property="og:description" content="Premium Clash Royale pack with full card tracking, elixir estimation and rooted VM.">
     <meta property="og:type" content="product">
     
     <!-- Canonical -->
-    <link rel="canonical" href="https://hackboot.fr/products/warzone/reaper.html" />
+    <link rel="canonical" href="https://hackboot.fr/products/cr/supreme.html" />
 
     <script>
         tailwind.config = {
@@ -187,7 +187,7 @@
             <i class="fas fa-chevron-right text-xs"></i>
             <a href="../../index.html#products" class="hover:text-accent transition">Products</a>
             <i class="fas fa-chevron-right text-xs"></i>
-            <span class="text-matrix">COD Warzone Reaper</span>
+            <span class="text-matrix">Clash Royale Supreme</span>
         </div>
     </div>
 
@@ -202,24 +202,23 @@
                             <i class="fas fa-crown text-xl text-white"></i>
                         </div>
                         <div>
-                            <span class="text-sm text-gray-400 uppercase tracking-wider">COD Warzone</span>
+                            <span class="text-sm text-gray-400 uppercase tracking-wider">Clash Royale</span>
                             <h1 class="text-3xl lg:text-4xl font-bold matrix-gradient matrix-glow">
-                                Reaper
+                                Supreme
                             </h1>
                         </div>
                     </div>
                     
-                    <p class="text-xl text-gray-300 mb-2">
-                        <span class="gradient-text font-semibold">Total Domination &amp; Zero Detection</span>
+                        <span class="gradient-text font-semibold">Arena Domination &amp; No Limits</span>
                     </p>
                     <p class="text-gray-400 mb-6 text-lg leading-relaxed">
-                        Reaper Pack offers unmatched control for COD Warzone. Advanced aimbot, extensive ESP and a secure VM with hardware spoofing for dominating every match.
+                        Supreme Pack provides full card tracking, real-time elixir and a rooted VM for unstoppable ladder progression.
                     </p>
                     
                     <!-- Price -->
                     <div class="mb-8">
                         <div class="flex items-baseline space-x-2 mb-2">
-                            <span class="text-4xl font-bold text-matrix">€600</span>
+                            <span class="text-4xl font-bold text-matrix">€180</span>
                             <span class="text-gray-400 text-lg">/month</span>
                         </div>
                         <div class="flex items-center space-x-2">
@@ -309,7 +308,7 @@
                     <span class="gradient-text">Ultimate</span> <span class="text-white">Features</span>
                 </h2>
                 <p class="text-gray-400 max-w-2xl mx-auto">
-                    The complete suite of advanced features for an unlimited COD Warzone experience.
+                    The complete suite of advanced features for an unlimited Clash Royale experience.
                 </p>
             </div>
             
@@ -325,31 +324,31 @@
                     <ul class="space-y-2 text-sm text-gray-300">
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Advanced aimbot with bone selection
+                            Full card tracking (hand, cycle, next card)
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Full ESP: players, loot & objectives
+                            Real-time opponent elixir estimation
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Smart triggerbot & radar hack
+                            Strategic overlay (range, impact, paths)
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            No recoil & bullet teleport
+                            Auto-match & 24/7 farming
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            AI prediction & FOV unlock
+                            Auto-claim chests, quests, pass
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Anti-flash & anti-smoke
+                            Automatic deck switch based on meta
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Auto ping & killstreak automation
+                            Matchmaking spoofing (target bypass)
                         </li>
                     </ul>
                 </div>
@@ -365,15 +364,23 @@
                     <ul class="space-y-2 text-sm text-gray-300">
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Stat faker (K/D, accuracy, wins)
+                            All cards at level 15
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            Maxed weapon levels & full unlock
+                            All evolutions unlocked
                         </li>
                         <li class="flex items-center">
                             <i class="fas fa-check text-accent text-xs mr-2"></i>
-                            SBMM bypass / manual matchmaking
+                            Access to all ladder decks and events
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            All cosmetics unlocked (emotes, skins, banners)
+                        </li>
+                        <li class="flex items-center">
+                            <i class="fas fa-check text-accent text-xs mr-2"></i>
+                            Free nickname and tag change
                         </li>
                     </ul>
                 </div>
@@ -439,33 +446,31 @@
                     </h3>
                     <div class="space-y-4">
                         <div class="spec-highlight p-4 rounded-lg">
-                            <h4 class="font-semibold text-matrix mb-2">Advanced Aimbot</h4>
+                            <h4 class="font-semibold text-matrix mb-2">Full Card Tools</h4>
                             <ul class="text-sm text-gray-300 space-y-1">
-                                <li>• Adjustable FOV (10-180°)</li>
-                                <li>• Customizable smoothing (0-100%)</li>
-                                <li>• Silent aim invisible to spectators</li>
-                                <li>• Bone selection (head, chest, feet)</li>
-                                <li>• Dynamic movement prediction</li>
+                                <li>• Full card tracking (hand, cycle, next card)</li>
+                                <li>• Real-time opponent elixir estimation</li>
+                                <li>• Strategic overlay (range, impact, paths)</li>
+                                <li>• Auto-match & 24/7 farming</li>
+                                <li>• Automatic deck switch (meta based)</li>
+                            <h4 class="font-semibold text-matrix mb-2">Unlocked Content</h4>
+                            <ul class="text-sm text-gray-300 space-y-1">
+                                <li>• All cards at level 15</li>
+                                <li>• All evolutions unlocked</li>
+                                <li>• Access to ladder decks & events</li>
+                                <li>• All cosmetics unlocked</li>
+                                <li>• Free nickname & tag change</li>
                             </ul>
                         </div>
                         
                         <div class="spec-highlight p-4 rounded-lg">
-                            <h4 class="font-semibold text-matrix mb-2">Total Unlocks</h4>
+                            <h4 class="font-semibold text-matrix mb-2">Automation Tools</h4>
                             <ul class="text-sm text-gray-300 space-y-1">
-                                  <li>• Stat faker (K/D, accuracy, wins)</li>
-                                  <li>• Max weapon levels & full unlock</li>
-                                  <li>• SBMM bypass / manual matchmaking</li>
-                            </ul>
-                        </div>
-                        
-                        <div class="spec-highlight p-4 rounded-lg">
-                            <h4 class="font-semibold text-matrix mb-2">AI & Automation</h4>
-                            <ul class="text-sm text-gray-300 space-y-1">
-                                <li>• AI-driven automated gameplay</li>
-                                <li>• Auto skill activation</li>
-                                <li>• Built-in macro/script editor</li>
-                                <li>• Smart anti-spectator mode</li>
-                                <li>• Behavioral humanization</li>
+                                <li>• Auto-claim chests & quests</li>
+                                <li>• Smart placement suggestions</li>
+                                <li>• AI deck prediction</li>
+                                <li>• Opponent cycle tracking</li>
+                                <li>• Matchmaking spoofing (target bypass)</li>
                             </ul>
                         </div>
                     </div>
@@ -504,7 +509,7 @@
                             <ul class="text-sm text-gray-300 space-y-1">
                                 <li>• OBS & ShadowPlay compatible</li>
                                 <li>• Automatic VM snapshots</li>
-                                <li>• Fail-safe on Warzone updates</li>
+                                <li>• Fail-safe on game updates</li>
                                 <li>• Secure authentication (2FA)</li>
                                 <li>• One-click full reset</li>
                             </ul>
@@ -564,7 +569,7 @@
                     </button>
                     <div id="faq-content-1" class="hidden mt-4 text-gray-300">
                         <p>
-                            The skin unlocker only works visually while you use Reaper. Skins appear unlocked on your screen, but they are not permanently added to your Blizzard account.
+                            The skin unlocker only works visually while you use Supreme. Skins appear unlocked on your screen, but they are not permanently added to your Blizzard account.
                         </p>
                     </div>
                 </div>
@@ -577,7 +582,7 @@
                     </button>
                     <div id="faq-content-2" class="hidden mt-4 text-gray-300">
                         <p>
-                            Reaper locally modifies the display of your level, portrait, stats and rank. You appear with the desired level (up to 999) and custom stats, but it's purely cosmetic.
+                            Supreme locally modifies the display of your level, portrait, stats and rank. You appear with the desired level (up to 999) and custom stats, but it's purely cosmetic.
                         </p>
                     </div>
                 </div>
@@ -585,12 +590,12 @@
                 <!-- Question 3 -->
                 <div class="card-gradient p-6 rounded-xl">
                     <button onclick="toggleFAQ(3)" class="flex justify-between items-center w-full">
-                        <h3 class="text-lg font-bold text-left">Can I stream with Reaper?</h3>
+                        <h3 class="text-lg font-bold text-left">Can I stream with Supreme?</h3>
                         <i id="faq-icon-3" class="fas fa-chevron-down transition-transform duration-300"></i>
                     </button>
                     <div id="faq-content-3" class="hidden mt-4 text-gray-300">
                         <p>
-                            Yes! Reaper is optimized for streaming with OBS and ShadowPlay. The anti-spectator mode automatically hides all cheat features when you're watched.
+                            Yes! Supreme is optimized for streaming with OBS and ShadowPlay. The anti-spectator mode automatically hides all cheat features when you're watched.
                         </p>
                     </div>
                 </div>
@@ -598,12 +603,12 @@
                 <!-- Question 4 -->
                 <div class="card-gradient p-6 rounded-xl">
                     <button onclick="toggleFAQ(4)" class="flex justify-between items-center w-full">
-                        <h3 class="text-lg font-bold text-left">What happens if Warzone updates?</h3>
+                        <h3 class="text-lg font-bold text-left">What happens if Clash Royale updates?</h3>
                         <i id="faq-icon-4" class="fas fa-chevron-down transition-transform duration-300"></i>
                     </button>
                     <div id="faq-content-4" class="hidden mt-4 text-gray-300">
                         <p>
-                            Reaper includes a fail-safe system that automatically disables the cheat when COD Warzone updates. Our team updates the software within 24-48h to stay compatible.
+                            Supreme includes a fail-safe system that automatically disables the cheat when Clash Royale updates. Our team updates the software within 24-48h to stay compatible.
                         </p>
                     </div>
                 </div>
@@ -619,7 +624,7 @@
                     <span class="matrix-gradient">Access</span> <span class="text-white">Absolute Control</span>
                 </h2>
                 <p class="text-gray-300 mb-8 max-w-2xl mx-auto">
-                    Join the fight with Reaper and enjoy unbeatable precision at an affordable price.
+                    Join the fight with Supreme and enjoy unbeatable precision at an affordable price.
                 </p>
                 
                 <!-- Package details -->
@@ -645,7 +650,7 @@
                     <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
                         <button class="px-10 py-4 rounded-lg bg-gradient-to-r from-matrix to-primary hover:scale-105 transition transform duration-300 font-bold shadow-lg text-lg">
                             <i class="fas fa-rocket mr-2"></i>
-                            Order Reaper - €600/month
+                            Order Supreme - €180/month
                         </button>
                     </a>
                     <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
@@ -701,7 +706,7 @@
                         </div>
                         <div>
                             <h3 class="text-lg font-bold">Warzone Reaper</h3>
-                            <p class="text-sm text-gray-400">€600/month</p>
+                            <p class="text-sm text-gray-400">€180/month</p>
                         </div>
                     </div>
                     <p class="text-gray-300 text-sm mb-4">

--- a/products/tools/performance-optimizer.html
+++ b/products/tools/performance-optimizer.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- products/tools/performance-optimizer.html -->
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Performance Optimizer | Hackboot</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="shortcut icon" href="../../img/favicon.ico" />
+    <meta name="description" content="Performance Optimizer - FPS unlock, lag reduction and system tuning. €19.99/month.">
+    <meta name="robots" content="index, follow">
+    <!-- Open Graph -->
+    <meta property="og:title" content="Performance Optimizer | Hackboot">
+    <meta property="og:description" content="Boost FPS, reduce lag and optimize your PC for competitive gaming.">
+    <meta property="og:type" content="product">
+    <!-- Canonical -->
+    <link rel="canonical" href="https://hackboot.fr/products/tools/performance-optimizer.html" />
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+            theme: {
+                extend: {
+                    colors: {
+                        primary: '#6d28d9',
+                        dark: '#121826',
+                        light: '#1f2937',
+                        accent: '#10b981',
+                        neon: '#00f0ff',
+                        matrix: '#00ff41'
+                    },
+                    animation: {
+                        'float': 'float 3s ease-in-out infinite',
+                        'text-gradient': 'text-gradient 6s ease infinite'
+                    },
+                    keyframes: {
+                        float: {
+                            '0%, 100%': { transform: 'translateY(0)' },
+                            '50%': { transform: 'translateY(-10px)' }
+                        },
+                        'text-gradient': {
+                            '0%, 100%': {
+                                'background-size': '200% 200%',
+                                'background-position': 'left center'
+                            },
+                            '50%': {
+                                'background-size': '200% 200%',
+                                'background-position': 'right center'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        .gradient-text {
+            background: linear-gradient(90deg, #00f0ff, #6d28d9, #10b981);
+            background-size: 200% auto;
+            color: transparent;
+            background-clip: text;
+        }
+        .bg-grid {
+            background-image:
+                linear-gradient(to right, rgba(31, 41, 55, 0.3) 1px, transparent 1px),
+                linear-gradient(to bottom, rgba(31, 41, 55, 0.3) 1px, transparent 1px);
+            background-size: 40px 40px;
+        }
+        .card-gradient {
+            background: linear-gradient(145deg, #1f2937, #121826);
+            border-radius: 16px;
+        }
+    </style>
+</head>
+<body class="bg-dark text-gray-200 font-sans bg-grid">
+    <!-- Header -->
+    <header class="border-b border-gray-800 bg-dark/80 backdrop-blur-lg sticky top-0 z-50">
+        <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+            <div class="flex items-center space-x-2">
+                <div class="w-8 h-8 rounded-full bg-gradient-to-br from-accent to-primary flex items-center justify-center">
+                    <i class="fas fa-gamepad"></i>
+                </div>
+                <a href="../../index.html" class="text-xl font-bold gradient-text bg-clip-text tracking-tighter">
+                    HACK<span class="text-white">BOOT</span>
+                </a>
+            </div>
+            <nav class="hidden md:flex space-x-8">
+                <a href="../../index.html#features" class="hover:text-accent transition">Features</a>
+                <a href="../../index.html#products" class="hover:text-accent transition">Products</a>
+                <a href="../../index.html#about" class="hover:text-accent transition">About</a>
+                <a href="../../index.html#faq" class="hover:text-accent transition">FAQ</a>
+            </nav>
+            <div class="flex items-center space-x-4">
+                <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <button class="hidden md:block px-4 py-2 rounded-lg bg-gradient-to-r from-accent to-primary hover:opacity-90 transition">
+                        Client Area
+                    </button>
+                </a>
+                <button class="md:hidden p-2 rounded-lg bg-light">
+                    <i class="fas fa-bars"></i>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <!-- Breadcrumb -->
+    <div class="container mx-auto px-4 py-4">
+        <div class="flex items-center space-x-2 text-sm text-gray-400">
+            <a href="../../index.html" class="hover:text-accent transition">Home</a>
+            <i class="fas fa-chevron-right text-xs"></i>
+            <a href="../../products.html#tools-products" class="hover:text-accent transition">Products</a>
+            <i class="fas fa-chevron-right text-xs"></i>
+            <span class="text-matrix">Performance Optimizer</span>
+        </div>
+    </div>
+
+    <!-- Hero Section -->
+    <section class="py-16">
+        <div class="container mx-auto px-4 flex flex-col lg:flex-row items-center gap-12">
+            <div class="lg:w-1/2">
+                <div class="flex items-center space-x-3 mb-4">
+                    <div class="w-12 h-12 rounded-xl bg-gradient-to-br from-matrix to-primary flex items-center justify-center">
+                        <i class="fas fa-code text-xl text-white"></i>
+                    </div>
+                    <div>
+                        <span class="text-sm text-gray-400 uppercase tracking-wider">Tool</span>
+                        <h1 class="text-3xl lg:text-4xl font-bold gradient-text">Performance Optimizer</h1>
+                    </div>
+                </div>
+                <p class="text-xl text-gray-300 mb-2">
+                    <span class="gradient-text font-semibold">FPS Booster Pro</span>
+                </p>
+                <p class="text-gray-400 mb-6 text-lg leading-relaxed">
+                    Boost your PC for competitive play with extreme FPS unlock and lag reduction.
+                </p>
+                <div class="mb-8">
+                    <span class="text-4xl font-bold text-primary">€19.99</span>
+                    <span class="text-gray-400">/month</span>
+                </div>
+            </div>
+            <div class="lg:w-1/2 flex justify-center">
+                <img src="../../img/injector.png" alt="Performance Optimizer" class="w-80 rounded-xl shadow-lg">
+            </div>
+        </div>
+    </section>
+
+    <!-- Features -->
+    <section class="py-12">
+        <div class="container mx-auto px-4">
+            <h2 class="text-2xl font-bold mb-6 text-center">
+                <span class="gradient-text">Key</span> <span class="text-white">Features</span>
+            </h2>
+            <div class="grid md:grid-cols-2 gap-6 max-w-3xl mx-auto">
+                <ul class="space-y-2 text-sm text-gray-300 card-gradient p-6">
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>FPS unlock (240+ FPS)</li>
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Input lag reduction</li>
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Memory optimization</li>
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Graphics enhancement</li>
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Network latency optimizer</li>
+                </ul>
+                <div class="card-gradient p-6 text-sm text-gray-300 space-y-2">
+                    <p>System optimization tool to maximize gaming performance.</p>
+                    <p><strong>FPS Boost:</strong> Unlocks native FPS limitations in games.</p>
+                    <p><strong>Input Optimization:</strong> Drastically reduces input lag.</p>
+                    <p><strong>System Tuning:</strong> Windows optimization for competitive gaming.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <footer class="py-8 border-t border-gray-800 text-center text-gray-400">
+        <p>Hackboot &copy; 2025</p>
+    </footer>
+</body>
+</html>

--- a/products/tools/streamer-shield.html
+++ b/products/tools/streamer-shield.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- products/tools/streamer-shield.html -->
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Streamer Shield | Hackboot</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="shortcut icon" href="../../img/favicon.ico" />
+    <meta name="description" content="Streamer Shield - hide cheat overlays while streaming. €24.99/month.">
+    <meta name="robots" content="index, follow">
+    <!-- Open Graph -->
+    <meta property="og:title" content="Streamer Shield | Hackboot">
+    <meta property="og:description" content="Keep cheats invisible on stream with automatic hiding and spectator protection.">
+    <meta property="og:type" content="product">
+    <!-- Canonical -->
+    <link rel="canonical" href="https://hackboot.fr/products/tools/streamer-shield.html" />
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+            theme: {
+                extend: {
+                    colors: {
+                        primary: '#6d28d9',
+                        dark: '#121826',
+                        light: '#1f2937',
+                        accent: '#10b981',
+                        neon: '#00f0ff',
+                        matrix: '#00ff41'
+                    },
+                    animation: {
+                        'float': 'float 3s ease-in-out infinite',
+                        'text-gradient': 'text-gradient 6s ease infinite'
+                    },
+                    keyframes: {
+                        float: {
+                            '0%, 100%': { transform: 'translateY(0)' },
+                            '50%': { transform: 'translateY(-10px)' }
+                        },
+                        'text-gradient': {
+                            '0%, 100%': {
+                                'background-size': '200% 200%',
+                                'background-position': 'left center'
+                            },
+                            '50%': {
+                                'background-size': '200% 200%',
+                                'background-position': 'right center'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        .gradient-text {
+            background: linear-gradient(90deg, #00f0ff, #6d28d9, #10b981);
+            background-size: 200% auto;
+            color: transparent;
+            background-clip: text;
+        }
+        .bg-grid {
+            background-image:
+                linear-gradient(to right, rgba(31, 41, 55, 0.3) 1px, transparent 1px),
+                linear-gradient(to bottom, rgba(31, 41, 55, 0.3) 1px, transparent 1px);
+            background-size: 40px 40px;
+        }
+        .card-gradient {
+            background: linear-gradient(145deg, #1f2937, #121826);
+            border-radius: 16px;
+        }
+    </style>
+</head>
+<body class="bg-dark text-gray-200 font-sans bg-grid">
+    <!-- Header -->
+    <header class="border-b border-gray-800 bg-dark/80 backdrop-blur-lg sticky top-0 z-50">
+        <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+            <div class="flex items-center space-x-2">
+                <div class="w-8 h-8 rounded-full bg-gradient-to-br from-accent to-primary flex items-center justify-center">
+                    <i class="fas fa-gamepad"></i>
+                </div>
+                <a href="../../index.html" class="text-xl font-bold gradient-text bg-clip-text tracking-tighter">
+                    HACK<span class="text-white">BOOT</span>
+                </a>
+            </div>
+            <nav class="hidden md:flex space-x-8">
+                <a href="../../index.html#features" class="hover:text-accent transition">Features</a>
+                <a href="../../index.html#products" class="hover:text-accent transition">Products</a>
+                <a href="../../index.html#about" class="hover:text-accent transition">About</a>
+                <a href="../../index.html#faq" class="hover:text-accent transition">FAQ</a>
+            </nav>
+            <div class="flex items-center space-x-4">
+                <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <button class="hidden md:block px-4 py-2 rounded-lg bg-gradient-to-r from-accent to-primary hover:opacity-90 transition">
+                        Client Area
+                    </button>
+                </a>
+                <button class="md:hidden p-2 rounded-lg bg-light">
+                    <i class="fas fa-bars"></i>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <!-- Breadcrumb -->
+    <div class="container mx-auto px-4 py-4">
+        <div class="flex items-center space-x-2 text-sm text-gray-400">
+            <a href="../../index.html" class="hover:text-accent transition">Home</a>
+            <i class="fas fa-chevron-right text-xs"></i>
+            <a href="../../products.html#tools-products" class="hover:text-accent transition">Products</a>
+            <i class="fas fa-chevron-right text-xs"></i>
+            <span class="text-matrix">Streamer Shield</span>
+        </div>
+    </div>
+
+    <!-- Hero Section -->
+    <section class="py-16">
+        <div class="container mx-auto px-4 flex flex-col lg:flex-row items-center gap-12">
+            <div class="lg:w-1/2">
+                <div class="flex items-center space-x-3 mb-4">
+                    <div class="w-12 h-12 rounded-xl bg-gradient-to-br from-matrix to-primary flex items-center justify-center">
+                        <i class="fas fa-code text-xl text-white"></i>
+                    </div>
+                    <div>
+                        <span class="text-sm text-gray-400 uppercase tracking-wider">Tool</span>
+                        <h1 class="text-3xl lg:text-4xl font-bold gradient-text">Streamer Shield</h1>
+                    </div>
+                </div>
+                <p class="text-xl text-gray-300 mb-2">
+                    <span class="gradient-text font-semibold">Invisible Gaming</span>
+                </p>
+                <p class="text-gray-400 mb-6 text-lg leading-relaxed">
+                    Protect your streams with automatic overlay hiding and anti-spectator detection.
+                </p>
+                <div class="mb-8">
+                    <span class="text-4xl font-bold text-primary">€24.99</span>
+                    <span class="text-gray-400">/month</span>
+                </div>
+            </div>
+            <div class="lg:w-1/2 flex justify-center">
+                <img src="../../img/injector.png" alt="Streamer Shield" class="w-80 rounded-xl shadow-lg">
+            </div>
+        </div>
+    </section>
+
+    <!-- Features -->
+    <section class="py-12">
+        <div class="container mx-auto px-4">
+            <h2 class="text-2xl font-bold mb-6 text-center">
+                <span class="gradient-text">Key</span> <span class="text-white">Features</span>
+            </h2>
+            <div class="grid md:grid-cols-2 gap-6 max-w-3xl mx-auto">
+                <ul class="space-y-2 text-sm text-gray-300 card-gradient p-6">
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Stream-proof overlays</li>
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Spectator protection</li>
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Recording detection</li>
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Automatic hiding system</li>
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Multiple monitor support</li>
+                </ul>
+                <div class="card-gradient p-6 text-sm text-gray-300 space-y-2">
+                    <p>Advanced protection for streamers using cheats during live sessions.</p>
+                    <p><strong>Smart Detection:</strong> Automatically detects OBS, Streamlabs, etc.</p>
+                    <p><strong>Overlay Management:</strong> Hides cheat elements during the stream.</p>
+                    <p><strong>Viewer Safety:</strong> Protection against suspicious spectators.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <footer class="py-8 border-t border-gray-800 text-center text-gray-400">
+        <p>Hackboot &copy; 2025</p>
+    </footer>
+</body>
+</html>

--- a/products/tools/universal-injector.html
+++ b/products/tools/universal-injector.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- products/tools/universal-injector.html -->
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Universal Injector | Hackboot</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="shortcut icon" href="../../img/favicon.ico" />
+    <meta name="description" content="Universal Injector - multi-game cheat loader with script support and memory protection bypass. €59.99/month.">
+    <meta name="robots" content="index, follow">
+    <!-- Open Graph -->
+    <meta property="og:title" content="Universal Injector | Hackboot">
+    <meta property="og:description" content="Inject cheats into 50+ games with script support and real-time updates.">
+    <meta property="og:type" content="product">
+    <!-- Canonical -->
+    <link rel="canonical" href="https://hackboot.fr/products/tools/universal-injector.html" />
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+            theme: {
+                extend: {
+                    colors: {
+                        primary: '#6d28d9',
+                        dark: '#121826',
+                        light: '#1f2937',
+                        accent: '#10b981',
+                        neon: '#00f0ff',
+                        matrix: '#00ff41'
+                    },
+                    animation: {
+                        'float': 'float 3s ease-in-out infinite',
+                        'text-gradient': 'text-gradient 6s ease infinite'
+                    },
+                    keyframes: {
+                        float: {
+                            '0%, 100%': { transform: 'translateY(0)' },
+                            '50%': { transform: 'translateY(-10px)' }
+                        },
+                        'text-gradient': {
+                            '0%, 100%': {
+                                'background-size': '200% 200%',
+                                'background-position': 'left center'
+                            },
+                            '50%': {
+                                'background-size': '200% 200%',
+                                'background-position': 'right center'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        .gradient-text {
+            background: linear-gradient(90deg, #00f0ff, #6d28d9, #10b981);
+            background-size: 200% auto;
+            color: transparent;
+            background-clip: text;
+        }
+        .bg-grid {
+            background-image:
+                linear-gradient(to right, rgba(31, 41, 55, 0.3) 1px, transparent 1px),
+                linear-gradient(to bottom, rgba(31, 41, 55, 0.3) 1px, transparent 1px);
+            background-size: 40px 40px;
+        }
+        .card-gradient {
+            background: linear-gradient(145deg, #1f2937, #121826);
+            border-radius: 16px;
+        }
+    </style>
+</head>
+<body class="bg-dark text-gray-200 font-sans bg-grid">
+    <!-- Header -->
+    <header class="border-b border-gray-800 bg-dark/80 backdrop-blur-lg sticky top-0 z-50">
+        <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+            <div class="flex items-center space-x-2">
+                <div class="w-8 h-8 rounded-full bg-gradient-to-br from-accent to-primary flex items-center justify-center">
+                    <i class="fas fa-gamepad"></i>
+                </div>
+                <a href="../../index.html" class="text-xl font-bold gradient-text bg-clip-text tracking-tighter">
+                    HACK<span class="text-white">BOOT</span>
+                </a>
+            </div>
+            <nav class="hidden md:flex space-x-8">
+                <a href="../../index.html#features" class="hover:text-accent transition">Features</a>
+                <a href="../../index.html#products" class="hover:text-accent transition">Products</a>
+                <a href="../../index.html#about" class="hover:text-accent transition">About</a>
+                <a href="../../index.html#faq" class="hover:text-accent transition">FAQ</a>
+            </nav>
+            <div class="flex items-center space-x-4">
+                <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <button class="hidden md:block px-4 py-2 rounded-lg bg-gradient-to-r from-accent to-primary hover:opacity-90 transition">
+                        Client Area
+                    </button>
+                </a>
+                <button class="md:hidden p-2 rounded-lg bg-light">
+                    <i class="fas fa-bars"></i>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <!-- Breadcrumb -->
+    <div class="container mx-auto px-4 py-4">
+        <div class="flex items-center space-x-2 text-sm text-gray-400">
+            <a href="../../index.html" class="hover:text-accent transition">Home</a>
+            <i class="fas fa-chevron-right text-xs"></i>
+            <a href="../../products.html#tools-products" class="hover:text-accent transition">Products</a>
+            <i class="fas fa-chevron-right text-xs"></i>
+            <span class="text-matrix">Universal Injector</span>
+        </div>
+    </div>
+
+    <!-- Hero Section -->
+    <section class="py-16">
+        <div class="container mx-auto px-4 flex flex-col lg:flex-row items-center gap-12">
+            <div class="lg:w-1/2">
+                <div class="flex items-center space-x-3 mb-4">
+                    <div class="w-12 h-12 rounded-xl bg-gradient-to-br from-matrix to-primary flex items-center justify-center">
+                        <i class="fas fa-code text-xl text-white"></i>
+                    </div>
+                    <div>
+                        <span class="text-sm text-gray-400 uppercase tracking-wider">Tool</span>
+                        <h1 class="text-3xl lg:text-4xl font-bold gradient-text">Universal Injector</h1>
+                    </div>
+                </div>
+                <p class="text-xl text-gray-300 mb-2">
+                    <span class="gradient-text font-semibold">Multi-Game Platform</span>
+                </p>
+                <p class="text-gray-400 mb-6 text-lg leading-relaxed">
+                    Inject cheats into over 50 games with memory protection bypass and custom script support.
+                </p>
+                <div class="mb-8">
+                    <span class="text-4xl font-bold text-primary">€59.99</span>
+                    <span class="text-gray-400">/month</span>
+                </div>
+            </div>
+            <div class="lg:w-1/2 flex justify-center">
+                <img src="../../img/injector.png" alt="Universal Injector" class="w-80 rounded-xl shadow-lg">
+            </div>
+        </div>
+    </section>
+
+    <!-- Features -->
+    <section class="py-12">
+        <div class="container mx-auto px-4">
+            <h2 class="text-2xl font-bold mb-6 text-center">
+                <span class="gradient-text">Key</span> <span class="text-white">Features</span>
+            </h2>
+            <div class="grid md:grid-cols-2 gap-6 max-w-3xl mx-auto">
+                <ul class="space-y-2 text-sm text-gray-300 card-gradient p-6">
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Injection dans 50+ jeux</li>
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Cheat loading system</li>
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Memory protection bypass</li>
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Custom script support</li>
+                    <li class="flex items-center"><i class="fas fa-check text-accent mr-2"></i>Real-time updates</li>
+                </ul>
+                <div class="card-gradient p-6 text-sm text-gray-300 space-y-2">
+                    <p>Universal platform for loading and managing cheats across multiple games.</p>
+                    <p><strong>Game Support:</strong> Compatible with all popular games and more.</p>
+                    <p><strong>Custom Scripts:</strong> Load your own mods and scripts.</p>
+                    <p><strong>Security:</strong> Advanced protection against anti-cheat systems.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <footer class="py-8 border-t border-gray-800 text-center text-gray-400">
+        <p>Hackboot &copy; 2025</p>
+    </footer>
+</body>
+</html>

--- a/products/warzone/reaper2.html
+++ b/products/warzone/reaper2.html
@@ -9,12 +9,15 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="shortcut icon" href="../../img/favicon.ico" />
 
-    <meta name="description" content="COD Warzone Reaper 2 - Advanced aimbot, full ESP and secure VM. €1650/month. Zero detection and complete control." />
-    <meta name="robots" content="index, follow" />
+    <meta name="description" content="COD Warzone Reaper 2 - Advanced aimbot, full ESP and secure VM. €1650/month. Zero detection and complete control.">
+    <meta name="robots" content="index, follow">
+    
     <!-- Open Graph -->
-    <meta property="og:title" content="COD Warzone Reaper 2 | Hackboot" />
-    <meta property="og:description" content="Premium Warzone cheat with ESP, triggerbot and hardware spoofing." />
-    <meta property="og:type" content="product" />
+    <meta property="og:title" content="COD Warzone Reaper 2 | Hackboot">
+    <meta property="og:description" content="Premium Warzone cheat with advanced aimbot, full ESP and secure VM. Zero detection guaranteed.">
+    <meta property="og:type" content="product">
+    
+    <!-- Canonical -->
     <link rel="canonical" href="https://hackboot.fr/products/warzone/reaper2.html" />
 
     <script>
@@ -28,73 +31,791 @@
                         light: '#1f2937',
                         accent: '#10b981',
                         neon: '#00f0ff',
-                        matrix: '#00ff41'
+                        matrix: '#00ff41',
+                        overwatch: '#f99e1a',
+                        dominion: '#9d4edd'
+                    },
+                    animation: {
+                        'float': 'float 3s ease-in-out infinite',
+                        'pulse-slow': 'pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+                        'text-gradient': 'text-gradient 6s ease infinite',
+                        'glow-pulse': 'glow-pulse 2s ease-in-out infinite alternate'
+                    },
+                    keyframes: {
+                        float: {
+                            '0%, 100%': { transform: 'translateY(0)' },
+                            '50%': { transform: 'translateY(-10px)' }
+                        },
+                        'text-gradient': {
+                            '0%, 100%': {
+                                'background-size': '200% 200%',
+                                'background-position': 'left center'
+                            },
+                            '50%': {
+                                'background-size': '200% 200%',
+                                'background-position': 'right center'
+                            }
+                        },
+                        'glow-pulse': {
+                            '0%': { boxShadow: '0 0 5px #9d4edd, 0 0 10px #9d4edd, 0 0 15px #9d4edd' },
+                            '100%': { boxShadow: '0 0 10px #9d4edd, 0 0 20px #9d4edd, 0 0 30px #9d4edd' }
+                        }
                     }
                 }
             }
         }
     </script>
+
+    <style>
+        .gradient-text {
+            background: linear-gradient(90deg, #00f0ff, #6d28d9, #10b981);
+            background-size: 200% auto;
+            color: transparent;
+            background-clip: text;
+        }
+        
+        .matrix-gradient {
+            background: linear-gradient(135deg, #00ff41, #10b981, #00ff9e);
+            background-size: 200% auto;
+            color: transparent;
+            background-clip: text;
+        }
+        
+        .glow {
+            text-shadow: 0 0 8px rgba(16, 185, 129, 0.6);
+        }
+        
+        .matrix-glow {
+            text-shadow: 0 0 10px rgba(0, 255, 65, 0.8);
+        }
+        
+        .bg-grid {
+            background-image: 
+                linear-gradient(to right, rgba(31, 41, 55, 0.3) 1px, transparent 1px),
+                linear-gradient(to bottom, rgba(31, 41, 55, 0.3) 1px, transparent 1px);
+            background-size: 40px 40px;
+        }
+        
+        .card-gradient {
+            background: linear-gradient(145deg, #1f2937, #121826);
+            border-radius: 16px;
+        }
+        
+        .card-gradient:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 10px 25px rgba(0, 255, 65, 0.2);
+        }
+        
+        .feature-card {
+            background: linear-gradient(145deg, rgba(31, 41, 55, 0.8), rgba(18, 24, 38, 0.9));
+            backdrop-filter: blur(10px);
+            border: 1px solid rgba(0, 255, 65, 0.2);
+        }
+        
+        .feature-card:hover {
+            border-color: rgba(0, 255, 65, 0.5);
+            transform: translateY(-3px);
+            box-shadow: 0 8px 25px rgba(0, 255, 65, 0.15);
+        }
+        
+        .neon-border {
+            position: relative;
+        }
+        
+        .neon-border::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            border-radius: 16px;
+            padding: 2px;
+            background: linear-gradient(45deg, #00ff41, #10b981);
+            -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+            -webkit-mask-composite: xor;
+            mask-composite: exclude;
+            pointer-events: none;
+        }
+        
+        .hero-bg {
+            background: radial-gradient(circle at top right, rgba(0, 255, 65, 0.1) 0%, transparent 50%),
+                        radial-gradient(circle at bottom left, rgba(0, 240, 255, 0.1) 0%, transparent 50%),
+                        linear-gradient(135deg, rgba(18, 24, 38, 0.95) 0%, rgba(31, 41, 55, 0.95) 100%);
+        }
+        
+        .spec-highlight {
+            background: linear-gradient(90deg, rgba(0, 255, 65, 0.1), rgba(16, 185, 129, 0.1));
+            border-left: 3px solid #00ff41;
+        }
+    </style>
 </head>
-<body class="bg-dark text-gray-200 font-sans">
-    <header class="py-4 border-b border-gray-800 bg-dark/80 backdrop-blur-lg sticky top-0 z-50">
-        <div class="container mx-auto px-4 flex justify-between items-center">
-            <a href="../../index.html" class="flex items-center space-x-2">
+<body class="bg-dark text-gray-200 font-sans bg-grid">
+    <!-- Header -->
+    <header class="border-b border-gray-800 bg-dark/80 backdrop-blur-lg sticky top-0 z-50">
+        <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+            <div class="flex items-center space-x-2">
                 <div class="w-8 h-8 rounded-full bg-gradient-to-br from-accent to-primary flex items-center justify-center">
                     <i class="fas fa-gamepad"></i>
                 </div>
-                <span class="text-xl font-bold gradient-text bg-clip-text tracking-tighter">HACK<span class="text-white">BOOT</span></span>
-            </a>
-            <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener" class="px-4 py-2 rounded-lg bg-gradient-to-r from-accent to-primary">Client Area</a>
+                <a href="../../index.html" class="text-xl font-bold gradient-text bg-clip-text tracking-tighter">
+                    HACK<span class="text-white">BOOT</span>
+                </a>
+            </div>
+            
+            <nav class="hidden md:flex space-x-8">
+                <a href="../../index.html#features" class="hover:text-accent transition">Features</a>
+                <a href="../../index.html#products" class="hover:text-accent transition">Products</a>
+                <a href="../../index.html#about" class="hover:text-accent transition">About</a>
+                <a href="../../index.html#faq" class="hover:text-accent transition">FAQ</a>
+            </nav>
+            
+            <div class="flex items-center space-x-4">
+                <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                    <button class="hidden md:block px-4 py-2 rounded-lg bg-gradient-to-r from-accent to-primary hover:opacity-90 transition">
+                        Client Area
+                    </button>
+                </a>
+                <button class="md:hidden p-2 rounded-lg bg-light">
+                    <i class="fas fa-bars"></i>
+                </button>
+            </div>
         </div>
     </header>
 
-    <section class="py-16">
-        <div class="container mx-auto px-4 flex flex-col lg:flex-row items-center gap-12">
-            <div class="lg:w-1/2">
-                <h1 class="text-4xl font-bold mb-4">COD Warzone Reaper 2</h1>
-                <p class="text-gray-300 mb-6">Total domination package for Warzone. Includes advanced aimbot, extensive ESP and rooted VM with spoofing.</p>
-                <div class="mb-6">
-                    <span class="text-4xl font-bold text-accent">€1650</span><span class="text-gray-400">/month</span>
+    <!-- Breadcrumb -->
+    <div class="container mx-auto px-4 py-4">
+        <div class="flex items-center space-x-2 text-sm text-gray-400">
+            <a href="../../index.html" class="hover:text-accent transition">Home</a>
+            <i class="fas fa-chevron-right text-xs"></i>
+            <a href="../../index.html#products" class="hover:text-accent transition">Products</a>
+            <i class="fas fa-chevron-right text-xs"></i>
+            <span class="text-matrix">COD Warzone Reaper 2</span>
+        </div>
+    </div>
+
+    <!-- Hero Section -->
+    <section class="py-16 hero-bg">
+        <div class="container mx-auto px-4">
+            <div class="flex flex-col lg:flex-row items-center gap-12">
+                <!-- Product Info -->
+                <div class="lg:w-1/2">
+                    <div class="flex items-center space-x-3 mb-4">
+                        <div class="w-12 h-12 rounded-xl bg-gradient-to-br from-matrix to-primary flex items-center justify-center">
+                            <i class="fas fa-crown text-xl text-white"></i>
+                        </div>
+                        <div>
+                            <span class="text-sm text-gray-400 uppercase tracking-wider">COD Warzone</span>
+                            <h1 class="text-3xl lg:text-4xl font-bold matrix-gradient matrix-glow">
+                                Reaper 2
+                            </h1>
+                        </div>
+                    </div>
+                    
+                    <p class="text-xl text-gray-300 mb-2">
+                        <span class="gradient-text font-semibold">Maximum Power &amp; Full Control</span>
+                    </p>
+                    <p class="text-gray-400 mb-6 text-lg leading-relaxed">
+                        The Reaper 2 pack offers full tactical and technical supremacy with high-end virtualization, packet-level manipulation, and competitive-grade automation.
+                    </p>
+                    
+                    <!-- Price -->
+                    <div class="mb-8">
+                        <div class="flex items-baseline space-x-2 mb-2">
+                            <span class="text-4xl font-bold text-matrix">€1650</span>
+                            <span class="text-gray-400 text-lg">/month</span>
+                        </div>
+                        <div class="flex items-center space-x-2">
+                            <span class="text-sm bg-matrix/20 text-matrix px-3 py-1 rounded-full">PACK 2</span>
+                            <span class="text-sm bg-accent/20 text-accent px-3 py-1 rounded-full">STANDARD</span>
+                        </div>
+                    </div>
+                    
+                    <!-- CTA Buttons -->
+                    <div class="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:space-x-4">
+                        <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                            <button class="w-full sm:w-auto px-8 py-4 rounded-lg bg-gradient-to-r from-matrix to-primary hover:scale-105 transition transform duration-300 font-bold shadow-lg">
+                                <i class="fas fa-crown mr-2"></i>
+                                Order Now
+                            </button>
+                        </a>
+                        <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                            <button class="w-full sm:w-auto px-8 py-4 rounded-lg border border-matrix text-matrix hover:bg-matrix/10 transition">
+                                <i class="fas fa-play mr-2"></i>
+                                View Demo
+                            </button>
+                        </a>
+                    </div>
                 </div>
-                <a href="https://t.me/HackBootCheat_bot" target="_blank" class="inline-block px-8 py-4 rounded-lg bg-gradient-to-r from-accent to-primary font-bold">Order Now</a>
-            </div>
-            <div class="lg:w-1/2">
-                <ul class="space-y-3 text-sm text-gray-300">
-                    <li><i class="fas fa-check text-accent mr-2"></i>Kernel-level packet manipulation</li>
-                    <li><i class="fas fa-check text-accent mr-2"></i>Server lag inducer & desync control</li>
-                    <li><i class="fas fa-check text-accent mr-2"></i>AI-controlled automation suite</li>
-                    <li><i class="fas fa-check text-accent mr-2"></i>Ghost lobbies & live enemy tracking</li>
-                    <li><i class="fas fa-check text-accent mr-2"></i>Ultra-VM 16GB RAM with spoofing</li>
-                    <li><i class="fas fa-check text-accent mr-2"></i>Streaming-proof overlay & kill switch</li>
-                </ul>
+                
+                <!-- Product Preview -->
+                <div class="lg:w-1/2">
+                    <div class="relative">
+                        <!-- Main preview card -->
+                        <div class="card-gradient p-8 rounded-2xl neon-border animate-float">
+                            <div class="text-center mb-6">
+                                <div class="w-20 h-20 mx-auto rounded-full bg-gradient-to-br from-matrix to-primary flex items-center justify-center mb-4">
+                                    <i class="fas fa-crown text-3xl text-white"></i>
+                                </div>
+                                <h3 class="text-xl font-bold text-matrix mb-2">Cheat Control System</h3>
+                                <p class="text-gray-400 text-sm">Complete control & customization</p>
+                            </div>
+                            
+                            <!-- Mock interface -->
+                            <div class="bg-dark/50 rounded-lg p-4 border border-matrix/20">
+                                <div class="flex justify-between items-center mb-3">
+                                    <span class="text-sm text-matrix">Skin Unlocker: ∞</span>
+                                    <span class="text-sm text-green-400">● ULTIMATE</span>
+                                </div>
+                                <div class="space-y-2">
+                                    <div class="flex justify-between">
+                                        <span class="text-xs text-gray-400">All Heroes</span>
+                                        <span class="text-xs text-accent">Unlocked</span>
+                                    </div>
+                                    <div class="flex justify-between">
+                                        <span class="text-xs text-gray-400">Fake Level</span>
+                                        <span class="text-xs text-accent">999</span>
+                                    </div>
+                                    <div class="flex justify-between">
+                                        <span class="text-xs text-gray-400">Rank Spoof</span>
+                                        <span class="text-xs text-accent">Grandmaster</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <!-- Floating stats -->
+                        <div class="absolute -top-6 -right-6 bg-gradient-to-br from-matrix/20 to-primary/20 backdrop-blur-lg rounded-lg p-4 border border-matrix/30">
+                            <div class="text-center">
+                                <div class="text-2xl font-bold text-matrix">∞</div>
+                                <div class="text-xs text-gray-400">Skins</div>
+                            </div>
+                        </div>
+                        
+                        <div class="absolute -bottom-6 -left-6 bg-gradient-to-br from-accent/20 to-primary/20 backdrop-blur-lg rounded-lg p-4 border border-accent/30">
+                            <div class="text-center">
+                                <div class="text-2xl font-bold text-accent">100%</div>
+                                <div class="text-xs text-gray-400">Access</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </section>
 
+    <!-- Features Overview -->
     <section class="py-16 bg-light/20">
         <div class="container mx-auto px-4">
-            <h2 class="text-3xl font-bold mb-6 text-center">Frequently Asked Questions</h2>
-            <div class="space-y-4 max-w-3xl mx-auto">
-                <div class="card-gradient p-6 rounded-xl">
-                    <h3 class="font-bold mb-2">Is the cheat stream proof?</h3>
-                    <p class="text-sm text-gray-300">Yes. Reaper hides all visuals from OBS and recording software.</p>
+            <div class="text-center mb-12">
+                <h2 class="text-3xl font-bold mb-4">
+                    <span class="gradient-text">Ultimate</span> <span class="text-white">Features</span>
+                </h2>
+                <p class="text-gray-400 max-w-2xl mx-auto">
+                    The complete suite of advanced features for an unlimited COD Warzone experience.
+                </p>
+            </div>
+            
+            <div class="grid md:grid-cols-3 gap-8">
+                <!-- Cheat Features -->
+                <div class="feature-card p-6 rounded-xl transition duration-300">
+                    <div class="flex items-center mb-4">
+                        <div class="w-10 h-10 rounded-lg bg-matrix/20 flex items-center justify-center mr-3">
+                            <i class="fas fa-crosshairs text-matrix"></i>
+                        </div>
+                        <h3 class="text-lg font-bold">Cheat Features</h3>
+                    </div>
+<ul class="space-y-2 text-sm text-gray-300">
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Kernel-level packet manipulation
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Server lag inducer & desync control
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Ping balancing exploit with latency shaping
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        AI-controlled smart automation
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Live macro editor + scenario scripting engine
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Ghost lobbies & live enemy tracking
+    </li>
+</ul>
                 </div>
-                <div class="card-gradient p-6 rounded-xl">
-                    <h3 class="font-bold mb-2">How is my hardware protected?</h3>
-                    <p class="text-sm text-gray-300">Our VM includes full spoofing and resets identifiers each session.</p>
+                
+                <!-- Unlock Features -->
+                <div class="feature-card p-6 rounded-xl transition duration-300">
+                    <div class="flex items-center mb-4">
+                        <div class="w-10 h-10 rounded-lg bg-accent/20 flex items-center justify-center mr-3">
+                            <i class="fas fa-unlock-alt text-accent"></i>
+                        </div>
+                        <h3 class="text-lg font-bold">Unlock Features</h3>
+                    </div>
+<ul class="space-y-2 text-sm text-gray-300">
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Unlock All Skins, Blueprints, Operators, Charms
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        XP & Token Spoofer (server persistent)
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Match history rewrite tool (fully custom)
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Prestige faker + rank freeze
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Tournament bypass & top 100 spoof
+    </li>
+</ul>
                 </div>
-                <div class="card-gradient p-6 rounded-xl">
-                    <h3 class="font-bold mb-2">What if the game updates?</h3>
-                    <p class="text-sm text-gray-300">The cheat auto-disables and our team issues an update within 24-48h.</p>
+                
+                <!-- VM Features -->
+                <div class="feature-card p-6 rounded-xl transition duration-300">
+                    <div class="flex items-center mb-4">
+                        <div class="w-10 h-10 rounded-lg bg-matrix/20 flex items-center justify-center mr-3">
+                            <i class="fas fa-server text-matrix"></i>
+                        </div>
+                        <h3 class="text-lg font-bold">VM Ultimate</h3>
+                    </div>
+<ul class="space-y-2 text-sm text-gray-300">
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Dedicated Ultra-VM: 16GB RAM, 6vCPU, RTX passthrough
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Real-time hardware fingerprint obfuscation
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Multi-layer spoofing: BIOS, SMBIOS, GPU, CPU & EFI
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Auto-rebuild HWID every session
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Remote kill switch + live session monitor
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Built-in shadowing and stealth cloaking layers
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        OBS / ShadowPlay streaming-proof overlay
+    </li>
+    <li class="flex items-center">
+        <i class="fas fa-check text-accent text-xs mr-2"></i>
+        Anti-patch survival module (auto isolate & rollback)
+    </li>
+</ul>
                 </div>
             </div>
         </div>
     </section>
 
+    <!-- Detailed Specifications -->
+    <section class="py-16">
+        <div class="container mx-auto px-4">
+            <div class="text-center mb-12">
+                <h2 class="text-3xl font-bold mb-4">
+                    <span class="text-white">Complete</span> <span class="gradient-text">Specifications</span>
+                </h2>
+            </div>
+            
+            <div class="grid lg:grid-cols-2 gap-8 max-w-6xl mx-auto">
+                <!-- Cheat & Unlock Features -->
+                <div class="card-gradient p-8 rounded-xl">
+                    <h3 class="text-xl font-bold mb-6 flex items-center">
+                        <i class="fas fa-magic text-matrix mr-3"></i>
+                        Premium Features
+                    </h3>
+                    <div class="space-y-4">
+                        <div class="spec-highlight p-4 rounded-lg">
+                            <h4 class="font-semibold text-matrix mb-2">Advanced Aimbot</h4>
+                            <ul class="text-sm text-gray-300 space-y-1">
+                                <li>• Adjustable FOV (10-180°)</li>
+                                <li>• Customizable smoothing (0-100%)</li>
+                                <li>• Silent aim invisible to spectators</li>
+                                <li>• Bone selection (head, chest, feet)</li>
+                                <li>• Dynamic movement prediction</li>
+                            </ul>
+                        </div>
+                        
+                        <div class="spec-highlight p-4 rounded-lg">
+                            <h4 class="font-semibold text-matrix mb-2">Total Unlocks</h4>
+                            <ul class="text-sm text-gray-300 space-y-1">
+                                  <li>• Stat faker (K/D, accuracy, wins)</li>
+                                  <li>• Max weapon levels & full unlock</li>
+                                  <li>• SBMM bypass / manual matchmaking</li>
+                            </ul>
+                        </div>
+                        
+                        <div class="spec-highlight p-4 rounded-lg">
+                            <h4 class="font-semibold text-matrix mb-2">AI & Automation</h4>
+                            <ul class="text-sm text-gray-300 space-y-1">
+                                <li>• AI-driven automated gameplay</li>
+                                <li>• Auto skill activation</li>
+                                <li>• Built-in macro/script editor</li>
+                                <li>• Smart anti-spectator mode</li>
+                                <li>• Behavioral humanization</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- VM & Security -->
+                <div class="card-gradient p-8 rounded-xl">
+                    <h3 class="text-xl font-bold mb-6 flex items-center">
+                        <i class="fas fa-shield-alt text-accent mr-3"></i>
+                        VM & Security Ultimate
+                    </h3>
+                    <div class="space-y-4">
+                        <div class="spec-highlight p-4 rounded-lg">
+                            <h4 class="font-semibold text-accent mb-2">Virtual Machine</h4>
+                            <ul class="text-sm text-gray-300 space-y-1">
+                                  <li>• Rooted VM with kernel injection</li>
+                                  <li>• 16 GB RAM & GPU passthrough</li>
+                                  <li>• High-speed SSD storage</li>
+                                  <li>• 120 FPS guaranteed</li>
+                                  <li>• Ping optimizer &lt; 10ms</li>
+                            </ul>
+                        </div>
+                        
+                        <div class="spec-highlight p-4 rounded-lg">
+                            <h4 class="font-semibold text-accent mb-2">Anti-Ban Protection</h4>
+                            <ul class="text-sm text-gray-300 space-y-1">
+                                <li>• Full hardware spoofer</li>
+                                <li>• Automatic HWID rotation</li>
+                                <li>• Built-in VPN with IP rotation</li>
+                                <li>• Fail-safe auto-disable on updates</li>
+                                <li>• 2FA authentication + HWID lock</li>
+                                </ul>
+                        
+                        <div class="spec-highlight p-4 rounded-lg">
+                            <h4 class="font-semibold text-accent mb-2">Advanced Features</h4>
+                            <ul class="text-sm text-gray-300 space-y-1">
+                                <li>• OBS & ShadowPlay compatible</li>
+                                <li>• Automatic VM snapshots</li>
+                                <li>• Fail-safe on Warzone updates</li>
+                                <li>• Secure authentication (2FA)</li>
+                                <li>• One-click full reset</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Performance Stats -->
+    <section class="py-16 bg-light/20">
+        <div class="container mx-auto px-4">
+            <div class="text-center mb-12">
+                <h2 class="text-3xl font-bold mb-4">
+                    <span class="gradient-text">Exceptional</span> <span class="text-white">Performance</span>
+                </h2>
+            </div>
+            
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
+                <div class="p-6">
+                    <div class="text-4xl font-bold text-matrix mb-2 glow">100%</div>
+                    <div class="text-gray-400">Full Access</div>
+                </div>
+                <div class="p-6">
+                    <div class="text-4xl font-bold text-accent mb-2">∞</div>
+                    <div class="text-gray-400">Unlocked Skins</div>
+                </div>
+                <div class="p-6">
+                    <div class="text-4xl font-bold text-overwatch mb-2">120</div>
+                    <div class="text-gray-400">FPS Constants</div>
+                </div>
+                <div class="p-6">
+                    <div class="text-4xl font-bold text-neon mb-2">&lt;10ms</div>
+                    <div class="text-gray-400">Latency</div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+
+    <!-- FAQ Section -->
+    <section class="py-16 bg-light/20">
+        <div class="container mx-auto px-4 max-w-4xl">
+            <div class="text-center mb-12">
+                <h2 class="text-3xl font-bold mb-4">
+                    <span class="gradient-text">Frequently</span> <span class="text-white">Asked Questions</span>
+                </h2>
+            </div>
+            
+            <div class="space-y-4">
+                <!-- Question 1 -->
+                <div class="card-gradient p-6 rounded-xl">
+                    <button onclick="toggleFAQ(1)" class="flex justify-between items-center w-full">
+                        <h3 class="text-lg font-bold text-left">Is the skin unlocker permanent?</h3>
+                        <i id="faq-icon-1" class="fas fa-chevron-down transition-transform duration-300"></i>
+                    </button>
+                    <div id="faq-content-1" class="hidden mt-4 text-gray-300">
+                        <p>
+                            The skin unlocker only works visually while you use Reaper 2. Skins appear unlocked on your screen, but they are not permanently added to your Blizzard account.
+                        </p>
+                    </div>
+                </div>
+                
+                <!-- Question 2 -->
+                <div class="card-gradient p-6 rounded-xl">
+                    <button onclick="toggleFAQ(2)" class="flex justify-between items-center w-full">
+                        <h3 class="text-lg font-bold text-left">How does the fake progression work?</h3>
+                        <i id="faq-icon-2" class="fas fa-chevron-down transition-transform duration-300"></i>
+                    </button>
+                    <div id="faq-content-2" class="hidden mt-4 text-gray-300">
+                        <p>
+                            Reaper 2 locally modifies the display of your level, portrait, stats and rank. You appear with the desired level (up to 999) and custom stats, but it's purely cosmetic.
+                        </p>
+                    </div>
+                </div>
+                
+                <!-- Question 3 -->
+                <div class="card-gradient p-6 rounded-xl">
+                    <button onclick="toggleFAQ(3)" class="flex justify-between items-center w-full">
+                        <h3 class="text-lg font-bold text-left">Can I stream with Reaper 2?</h3>
+                        <i id="faq-icon-3" class="fas fa-chevron-down transition-transform duration-300"></i>
+                    </button>
+                    <div id="faq-content-3" class="hidden mt-4 text-gray-300">
+                        <p>
+                            Yes! Reaper 2 is optimized for streaming with OBS and ShadowPlay. The anti-spectator mode automatically hides all cheat features when you're watched.
+                        </p>
+                    </div>
+                </div>
+                
+                <!-- Question 4 -->
+                <div class="card-gradient p-6 rounded-xl">
+                    <button onclick="toggleFAQ(4)" class="flex justify-between items-center w-full">
+                        <h3 class="text-lg font-bold text-left">What happens if Warzone updates?</h3>
+                        <i id="faq-icon-4" class="fas fa-chevron-down transition-transform duration-300"></i>
+                    </button>
+                    <div id="faq-content-4" class="hidden mt-4 text-gray-300">
+                        <p>
+                            Reaper 2 includes a fail-safe system that automatically disables the cheat when COD Warzone updates. Our team updates the software within 24-48h to stay compatible.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Purchase Section -->
+    <section class="py-16">
+        <div class="container mx-auto px-4">
+            <div class="bg-gradient-to-r from-matrix/20 to-primary/20 rounded-2xl p-12 text-center neon-border max-w-4xl mx-auto">
+                <h2 class="text-3xl md:text-4xl font-bold mb-6">
+                    <span class="matrix-gradient">Access</span> <span class="text-white">Absolute Control</span>
+                </h2>
+                <p class="text-gray-300 mb-8 max-w-2xl mx-auto">
+                    Join the fight with Reaper 2 and enjoy unbeatable precision at an affordable price.
+                </p>
+                
+                <!-- Package details -->
+                <div class="grid md:grid-cols-3 gap-6 mb-8">
+                    <div class="bg-dark/50 rounded-lg p-4">
+                        <i class="fas fa-unlock-alt text-matrix text-2xl mb-2"></i>
+                        <h4 class="font-bold mb-1">Total Access</h4>
+                        <p class="text-sm text-gray-400">Lootboxes & quests</p>
+                    </div>
+                    <div class="bg-dark/50 rounded-lg p-4">
+                        <i class="fas fa-server text-accent text-2xl mb-2"></i>
+                        <h4 class="font-bold mb-1">VM Ultimate</h4>
+                        <p class="text-sm text-gray-400">16GB RAM + snapshots</p>
+                    </div>
+                    <div class="bg-dark/50 rounded-lg p-4">
+                        <i class="fas fa-crown text-neon text-2xl mb-2"></i>
+                        <h4 class="font-bold mb-1">Support Premium</h4>
+                        <p class="text-sm text-gray-400">24/7 assistance</p>
+                    </div>
+                </div>
+                
+                <div class="flex flex-col sm:flex-row justify-center space-y-4 sm:space-y-0 sm:space-x-6">
+                    <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                        <button class="px-10 py-4 rounded-lg bg-gradient-to-r from-matrix to-primary hover:scale-105 transition transform duration-300 font-bold shadow-lg text-lg">
+                            <i class="fas fa-rocket mr-2"></i>
+                            Order Reaper 2 - €1650/month
+                        </button>
+                    </a>
+                    <a href="https://t.me/HackBootCheat_bot" target="_blank" rel="noopener noreferrer">
+                        <button class="px-10 py-4 rounded-lg border-2 border-matrix text-matrix hover:bg-matrix/10 transition text-lg">
+                            <i class="fas fa-question-circle mr-2"></i>
+                            Ask a Question
+                        </button>
+                    </a>
+                </div>
+                
+                <div class="mt-6 text-sm text-gray-400">
+                    <p>✅ Instant installation • ✅ 7-day money back guarantee • ✅ Free updates</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Related Products -->
+    <section class="py-16 bg-light/20">
+        <div class="container mx-auto px-4">
+            <div class="text-center mb-12">
+                <h2 class="text-3xl font-bold mb-4">
+                    <span class="text-white">Other</span> <span class="gradient-text">Products</span>
+                </h2>
+                <p class="text-gray-400">Discover our other premium cheat solutions</p>
+            </div>
+            
+            <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+                <!-- Overwatch Phantom -->
+                <div class="card-gradient p-6 rounded-xl transition duration-300 hover:transform hover:scale-105">
+                    <div class="flex items-center mb-4">
+                        <div class="w-12 h-12 rounded-lg bg-overwatch/20 flex items-center justify-center mr-4">
+                            <i class="fas fa-crosshairs text-overwatch"></i>
+                        </div>
+                        <div>
+                            <h3 class="text-lg font-bold">Overwatch 2 Phantom</h3>
+                            <p class="text-sm text-gray-400">€410/month</p>
+                        </div>
+                    </div>
+                    <p class="text-gray-300 text-sm mb-4">
+                        Advanced Overwatch 2 cheat with precision aimbot, full ESP and dedicated VM.
+                    </p>
+                    <a href="../overwatch/phantom.html" class="text-overwatch hover:text-overwatch/80 transition text-sm">
+                        Learn more →
+                    </a>
+                </div>
+                
+                <!-- Warzone -->
+                <div class="card-gradient p-6 rounded-xl transition duration-300 hover:transform hover:scale-105">
+                    <div class="flex items-center mb-4">
+                        <div class="w-12 h-12 rounded-lg bg-matrix/20 flex items-center justify-center mr-4">
+                            <i class="fas fa-skull-crossbones text-matrix"></i>
+                        </div>
+                        <div>
+                            <h3 class="text-lg font-bold">Warzone Reaper</h3>
+                            <p class="text-sm text-gray-400">€1650/month</p>
+                        </div>
+                    </div>
+                    <p class="text-gray-300 text-sm mb-4">
+                        Ultimate Warzone cheat with aimbot, ESP, god mode and full radar hack.
+                    </p>
+                    <a href="../../index.html#products" class="text-matrix hover:text-matrix/80 transition text-sm">
+                        Learn more →
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
     <footer class="bg-dark border-t border-gray-800 py-12">
-        <div class="container mx-auto px-4 text-center">
-            <p class="text-gray-400">© 2025 Hackboot. All rights reserved.</p>
+        <div class="container mx-auto px-4">
+            <div class="text-center">
+                <div class="flex items-center justify-center space-x-2 mb-6">
+                    <div class="w-8 h-8 rounded-full bg-gradient-to-br from-accent to-primary flex items-center justify-center">
+                        <i class="fas fa-gamepad"></i>
+                    </div>
+                    <span class="text-xl font-bold gradient-text bg-clip-text tracking-tighter">
+                        HACK<span class="text-white">BOOT</span>
+                    </span>
+                </div>
+                <p class="text-gray-400 mb-6">
+                    Premium gaming tools for competitive players since 2020.
+                </p>
+                <div class="flex justify-center space-x-4 mb-8">
+                    <a href="https://t.me/HackBootCheat_bot" class="text-gray-400 hover:text-accent transition">
+                        <i class="fab fa-telegram text-xl"></i>
+                    </a>
+                </div>
+                <div class="border-t border-gray-800 pt-6">
+                    <p class="text-gray-400 text-sm">© 2025 Hackboot. All rights reserved. Not affiliated with Blizzard Entertainment.</p>
+                    <p class="text-gray-400 text-xs mt-2">For entertainment purposes only.</p>
+                </div>
+            </div>
         </div>
     </footer>
+
+    <script>
+        // Toggle FAQ items
+        function toggleFAQ(num) {
+            const content = document.getElementById(`faq-content-${num}`);
+            const icon = document.getElementById(`faq-icon-${num}`);
+            
+            content.classList.toggle('hidden');
+            icon.classList.toggle('rotate-180');
+        }
+        
+        // Smooth scroll for anchor links
+        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+            anchor.addEventListener('click', function(e) {
+                e.preventDefault();
+                const targetId = this.getAttribute('href');
+                const targetElement = document.querySelector(targetId);
+                
+                if (targetElement) {
+                    targetElement.scrollIntoView({
+                        behavior: 'smooth',
+                        block: 'start'
+                    });
+                }
+            });
+        });
+        
+        // Animate elements on scroll
+        const observerOptions = {
+            root: null,
+            rootMargin: '0px',
+            threshold: 0.1
+        };
+        
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('animate-fade-in');
+                }
+            });
+        }, observerOptions);
+        
+        // Observe all feature cards and sections
+        document.querySelectorAll('.feature-card, .card-gradient').forEach(el => {
+            observer.observe(el);
+        });
+        
+        // Add fade-in animation class
+        const style = document.createElement('style');
+        style.textContent = `
+            .animate-fade-in {
+                animation: fadeInUp 0.6s ease-out forwards;
+            }
+            
+            @keyframes fadeInUp {
+                from {
+                    opacity: 0;
+                    transform: translateY(30px);
+                }
+                to {
+                    opacity: 1;
+                    transform: translateY(0);
+                }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create three new tool pages under `products/tools/`
- link Tool cards to these pages in products listing

## Testing
- `npx htmlhint products.html` *(failed: required npm package could not be installed)*
- `npx htmlhint products/tools/universal-injector.html` *(failed: required npm package could not be installed)*
- `npx htmlhint products/tools/performance-optimizer.html` *(failed: required npm package could not be installed)*
- `npx htmlhint products/tools/streamer-shield.html` *(failed: required npm package could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6880c7eab9c88333a92177041e812338