### PR TITLE
Remove About button from all headers

### DIFF
--- a/about.html
+++ b/about.html
@@ -31,7 +31,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="products.html" class="hover:text-accent transition">Products</a>
-                <a href="about.html" class="hover:text-accent transition">About</a>
                 <a href="update.html" class="hover:text-accent transition">Update</a>
             </nav>
             <div class="flex items-center space-x-4">

--- a/account/login.html
+++ b/account/login.html
@@ -122,7 +122,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="../index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="../products.html" class="hover:text-accent transition">Products</a>
-                <a href="about.html" class="hover:text-accent transition">About</a>
                 <a href="update.html" class="hover:text-accent transition">Update</a>
             </nav>
             <div class="flex items-center space-x-4">

--- a/changelog.html
+++ b/changelog.html
@@ -167,7 +167,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="products.html" class="hover:text-accent transition">Products</a>
-                <a href="about.html" class="hover:text-accent transition">About</a>
                 <a href="update.html" class="hover:text-accent transition">Update</a>
             </nav>
             

--- a/changelog/update/1.3.html
+++ b/changelog/update/1.3.html
@@ -489,7 +489,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="../../index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="../../products.html" class="hover:text-accent transition">Products</a>
-                <a href="../../about.html" class="hover:text-accent transition">About</a>
                 <a href="../../update.html" class="hover:text-accent transition">Update</a>
             </nav>
             
@@ -792,108 +791,108 @@
             <!-- Grille des prix -->
             <div class="grid lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
                 <!-- Clash Royale -->
-                <div class="card-gradient p-8 rounded-xl">
-                    <div class="flex items-center justify-between mb-6">
-                        <h3 class="text-2xl font-bold">Clash Royale</h3>
-                        <div class="w-12 h-12 rounded-lg bg-accent/20 flex items-center justify-center">
+                <div class="card-gradient p-8 rounded-xl text-center">
+                    <div class="mb-6">
+                        <div class="w-12 h-12 mx-auto rounded-lg bg-accent/20 flex items-center justify-center mb-2">
                             <i class="fas fa-chess-knight text-2xl text-accent"></i>
                         </div>
+                        <h3 class="text-2xl font-bold">Clash Royale</h3>
                     </div>
                     
                     <div class="space-y-4">
-                        <div class="flex justify-between items-center p-3 bg-dark/50 rounded-lg">
-                            <span>Supreme</span>
-                            <div class="text-right">
+                        <div class="p-3 bg-dark/50 rounded-lg flex flex-col items-center">
+                            <span class="font-semibold">Supreme</span>
+                            <div class="mt-1 space-x-2">
                                 <span class="price-old text-sm">€180</span>
-                                <span class="price-new text-xl ml-2">€130</span>
-                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded ml-2">-28%</span>
+                                <span class="price-new text-xl">€130</span>
+                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded">-28%</span>
                             </div>
                         </div>
                         
-                        <div class="flex justify-between items-center p-3 bg-dark/50 rounded-lg">
-                            <span>Dominator</span>
-                            <div class="text-right">
+                        <div class="p-3 bg-dark/50 rounded-lg flex flex-col items-center">
+                            <span class="font-semibold">Dominator</span>
+                            <div class="mt-1 space-x-2">
                                 <span class="price-old text-sm">€230</span>
-                                <span class="price-new text-xl ml-2">€180</span>
-                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded ml-2">-22%</span>
+                                <span class="price-new text-xl">€180</span>
+                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded">-22%</span>
                             </div>
                         </div>
                         
-                        <div class="flex justify-between items-center p-3 bg-dark/50 rounded-lg">
-                            <span>Godmode</span>
-                            <div class="text-right">
+                        <div class="p-3 bg-dark/50 rounded-lg flex flex-col items-center">
+                            <span class="font-semibold">Godmode</span>
+                            <div class="mt-1 space-x-2">
                                 <span class="price-old text-sm">€290</span>
-                                <span class="price-new text-xl ml-2">€230</span>
-                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded ml-2">-21%</span>
+                                <span class="price-new text-xl">€230</span>
+                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded">-21%</span>
                             </div>
                         </div>
                     </div>
                 </div>
 
                 <!-- Overwatch 2 -->
-                <div class="card-gradient p-8 rounded-xl">
-                    <div class="flex items-center justify-between mb-6">
-                        <h3 class="text-2xl font-bold">Overwatch 2</h3>
-                        <div class="w-12 h-12 rounded-lg bg-matrix/20 flex items-center justify-center">
+                <div class="card-gradient p-8 rounded-xl text-center">
+                    <div class="mb-6">
+                        <div class="w-12 h-12 mx-auto rounded-lg bg-matrix/20 flex items-center justify-center mb-2">
                             <i class="fas fa-crosshairs text-2xl text-matrix"></i>
                         </div>
+                        <h3 class="text-2xl font-bold">Overwatch 2</h3>
                     </div>
                     
                     <div class="space-y-4">
-                        <div class="flex justify-between items-center p-3 bg-dark/50 rounded-lg">
-                            <span>Phantom</span>
-                            <div class="text-right">
+                        <div class="p-3 bg-dark/50 rounded-lg flex flex-col items-center">
+                            <span class="font-semibold">Phantom</span>
+                            <div class="mt-1 space-x-2">
                                 <span class="price-old text-sm">€410</span>
-                                <span class="price-new text-xl ml-2">€380</span>
-                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded ml-2">-7%</span>
+                                <span class="price-new text-xl">€380</span>
+                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded">-7%</span>
                             </div>
                         </div>
                         
-                        <div class="flex justify-between items-center p-3 bg-dark/50 rounded-lg">
-                            <span>Dominion</span>
-                            <div class="text-right">
+                        <div class="p-3 bg-dark/50 rounded-lg flex flex-col items-center">
+                            <span class="font-semibold">Dominion</span>
+                            <div class="mt-1 space-x-2">
                                 <span class="price-old text-sm">€600</span>
-                                <span class="price-new text-xl ml-2">€500</span>
-                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded ml-2">-17%</span>
+                                <span class="price-new text-xl">€500</span>
+                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded">-17%</span>
                             </div>
                         </div>
                         
-                        <div class="flex justify-between items-center p-3 bg-dark/50 rounded-lg">
-                            <span>Godmode</span>
-                            <div class="text-right">
+                        <div class="p-3 bg-dark/50 rounded-lg flex flex-col items-center">
+                            <span class="font-semibold">Godmode</span>
+                            <div class="mt-1 space-x-2">
                                 <span class="price-old text-sm">€1000</span>
-                                <span class="price-new text-xl ml-2">€850</span>
-                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded ml-2">-15%</span>
+                                <span class="price-new text-xl">€850</span>
+                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded">-15%</span>
                             </div>
                         </div>
                     </div>
                 </div>
 
                 <!-- Warzone -->
-                <div class="card-gradient p-8 rounded-xl">
-                    <div class="flex items-center justify-between mb-6">
-                        <h3 class="text-2xl font-bold">Warzone</h3>
-                        <div class="w-12 h-12 rounded-lg bg-primary/20 flex items-center justify-center">
+                <div class="card-gradient p-8 rounded-xl text-center">
+                    <div class="mb-6">
+                        <div class="w-12 h-12 mx-auto rounded-lg bg-primary/20 flex items-center justify-center mb-2">
                             <i class="fas fa-skull text-2xl text-primary"></i>
                         </div>
+                        <h3 class="text-2xl font-bold">Warzone</h3>
                     </div>
                     
                     <div class="space-y-4">
-                        <div class="flex justify-between items-center p-3 bg-dark/50 rounded-lg">
-                            <span>Reaper</span>
-                            <div class="text-right">
+                        <div class="p-3 bg-dark/50 rounded-lg flex flex-col items-center">
+                            <span class="font-semibold">Reaper</span>
+                            <div class="mt-1 space-x-2">
                                 <span class="price-old text-sm">€600</span>
-                                <span class="price-new text-xl ml-2">€500</span>
-                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded ml-2">-17%</span>
+                                <span class="price-new text-xl">€500</span>
+                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded">-17%</span>
                             </div>
                         </div>
                         
-                        <div class="flex justify-between items-center p-3 bg-dark/50 rounded-lg">
-                            <span>Reaper 2</span>
-                            <div class="text-right">
+                        <div class="p-3 bg-dark/50 rounded-lg flex flex-col items-center">
+                            <span class="font-semibold">Reaper 2</span>
+                            <div class="mt-1 space-x-2">
                                 <span class="price-old text-sm">€1650</span>
-                                <span class="price-new text-xl ml-2">€900</span>
-                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded ml-2">-45%</span>
+                                <span class="price-new text-xl">€900</span>
+                                <span class="text-xs bg-red-500 text-white px-2 py-1 rounded">-45%</span>
                             </div>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -171,7 +171,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="products.html" class="hover:text-accent transition">Products</a>
-                <a href="about.html" class="hover:text-accent transition">About</a>
                 <a href="update.html" class="hover:text-accent transition">Update</a>
             </nav>
             

--- a/products.html
+++ b/products.html
@@ -575,7 +575,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="index.html" class="hover:text-accent transition">Home</a>
                 <a href="products.html" class="hover:text-accent transition">Products</a>
-                <a href="about.html" class="hover:text-accent transition">About</a>
                 <a href="update.html" class="hover:text-accent transition">Updates</a>
             </nav>
             
@@ -607,7 +606,6 @@
         <nav class="flex flex-col space-y-4">
             <a href="index.html" class="text-xl hover:text-accent transition">Home</a>
             <a href="products.html" class="text-xl hover:text-accent transition">Products</a>
-            <a href="about.html" class="text-xl hover:text-accent transition">About</a>
             <a href="account/login.html" class="text-xl hover:text-accent transition">Client Area</a>
         </nav>
     </div>

--- a/products/cr/dominator.html
+++ b/products/cr/dominator.html
@@ -221,7 +221,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="../../index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="../../products.html" class="hover:text-accent transition">Products</a>
-                <a href="../../about.html" class="hover:text-accent transition">About</a>
             </nav>
             
             <div class="flex items-center space-x-4">

--- a/products/cr/godmode.html
+++ b/products/cr/godmode.html
@@ -258,7 +258,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="../../index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="../../products.html" class="hover:text-accent transition">Products</a>
-                <a href="../../about.html" class="hover:text-accent transition">About</a>
             </nav>
             
             <div class="flex items-center space-x-4">

--- a/products/cr/supreme.html
+++ b/products/cr/supreme.html
@@ -220,7 +220,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="../../index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="../../products.html" class="hover:text-accent transition">Products</a>
-                <a href="../../about.html" class="hover:text-accent transition">About</a>
             </nav>
             
             <div class="flex items-center space-x-4">

--- a/products/overwatch/dominion.html
+++ b/products/overwatch/dominion.html
@@ -179,7 +179,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="../../index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="../../products.html" class="hover:text-accent transition">Products</a>
-                <a href="../../about.html" class="hover:text-accent transition">About</a>
             </nav>
             
             <div class="flex items-center space-x-4">

--- a/products/overwatch/godmode.html
+++ b/products/overwatch/godmode.html
@@ -179,7 +179,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="../../index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="../../products.html" class="hover:text-accent transition">Products</a>
-                <a href="../../about.html" class="hover:text-accent transition">About</a>
             </nav>
             
             <div class="flex items-center space-x-4">

--- a/products/overwatch/phantom.html
+++ b/products/overwatch/phantom.html
@@ -180,7 +180,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="../../index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="../../products.html" class="hover:text-accent transition">Products</a>
-                <a href="../../about.html" class="hover:text-accent transition">About</a>
             </nav>
             
             <div class="flex items-center space-x-4">

--- a/products/tools/performance-optimizer.html
+++ b/products/tools/performance-optimizer.html
@@ -180,7 +180,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="../../index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="../../products.html" class="hover:text-accent transition">Products</a>
-                <a href="../../about.html" class="hover:text-accent transition">About</a>
             </nav>
             
             <div class="flex items-center space-x-4">

--- a/products/tools/streamer-shield.html
+++ b/products/tools/streamer-shield.html
@@ -180,7 +180,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="../../index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="../../products.html" class="hover:text-accent transition">Products</a>
-                <a href="../../about.html" class="hover:text-accent transition">About</a>
             </nav>
             
             <div class="flex items-center space-x-4">

--- a/products/tools/universal-injector.html
+++ b/products/tools/universal-injector.html
@@ -180,7 +180,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="../../index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="../../products.html" class="hover:text-accent transition">Products</a>
-                <a href="../../about.html" class="hover:text-accent transition">About</a>
             </nav>
             
             <div class="flex items-center space-x-4">

--- a/products/warzone/reaper.html
+++ b/products/warzone/reaper.html
@@ -180,7 +180,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="../../index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="../../products.html" class="hover:text-accent transition">Products</a>
-                <a href="../../about.html" class="hover:text-accent transition">About</a>
             </nav>
             
             <div class="flex items-center space-x-4">

--- a/products/warzone/reaper2.html
+++ b/products/warzone/reaper2.html
@@ -180,7 +180,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="../../index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="../../products.html" class="hover:text-accent transition">Products</a>
-                <a href="../../about.html" class="hover:text-accent transition">About</a>
             </nav>
             
             <div class="flex items-center space-x-4">

--- a/update.html
+++ b/update.html
@@ -183,7 +183,6 @@
             <nav class="hidden md:flex space-x-8">
                 <a href="index.html" class="hover:text-accent transition">Homepage</a>
                 <a href="products.html" class="hover:text-accent transition">Products</a>
-                <a href="about.html" class="hover:text-accent transition">About</a>
                 <a href="update.html" class="hover:text-accent transition">Update</a>
             </nav>
             


### PR DESCRIPTION
## Summary
- remove About navigation link from every page header
- center content for the price cards in changelog update 1.3

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68882af7fb48833382c08a942e92a626